### PR TITLE
introduce glog, remove log.logger references

### DIFF
--- a/cmd/kyverno/kyverno.go
+++ b/cmd/kyverno/kyverno.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
 
+	"github.com/nirmata/kyverno/pkg/config"
 	kyverno "github.com/nirmata/kyverno/pkg/kyverno"
+	flag "github.com/spf13/pflag"
 )
 
+func init() {
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	config.LogDefaultFlags()
+	flag.Parse()
+}
 func main() {
 	cmd := kyverno.NewDefaultKyvernoCommand()
 

--- a/init.go
+++ b/init.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"log"
-
+	"github.com/golang/glog"
 	client "github.com/nirmata/kyverno/pkg/dclient"
 	tls "github.com/nirmata/kyverno/pkg/tls"
 	"github.com/nirmata/kyverno/pkg/version"
@@ -12,17 +11,17 @@ import (
 
 func printVersionInfo() {
 	v := version.GetVersion()
-	log.Printf("Kyverno version: %s\n", v.BuildVersion)
-	log.Printf("Kyverno BuildHash: %s\n", v.BuildHash)
-	log.Printf("Kyverno BuildTime: %s\n", v.BuildTime)
+	glog.Infof("Kyverno version: %s\n", v.BuildVersion)
+	glog.Infof("Kyverno BuildHash: %s\n", v.BuildHash)
+	glog.Infof("Kyverno BuildTime: %s\n", v.BuildTime)
 }
 
 func createClientConfig(kubeconfig string) (*rest.Config, error) {
 	if kubeconfig == "" {
-		log.Printf("Using in-cluster configuration")
+		glog.Info("Using in-cluster configuration")
 		return rest.InClusterConfig()
 	}
-	log.Printf("Using configuration from '%s'", kubeconfig)
+	glog.Infof("Using configuration from '%s'", kubeconfig)
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
 }
 
@@ -36,14 +35,14 @@ func initTlsPemPair(configuration *rest.Config, client *client.Client) (*tls.Tls
 	}
 	tlsPair := client.ReadTlsPair(certProps)
 	if tls.IsTlsPairShouldBeUpdated(tlsPair) {
-		log.Printf("Generating new key/certificate pair for TLS")
+		glog.Info("Generating new key/certificate pair for TLS")
 		tlsPair, err = client.GenerateTlsPemPair(certProps)
 		if err != nil {
 			return nil, err
 		}
 		err = client.WriteTlsPair(certProps, tlsPair)
 		if err != nil {
-			log.Printf("Unable to save TLS pair to the cluster: %v", err)
+			glog.Errorf("Unable to save TLS pair to the cluster: %v", err)
 		}
 	}
 	return tlsPair, nil

--- a/main.go
+++ b/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"flag"
-	"log"
 
+	"github.com/golang/glog"
+	"github.com/nirmata/kyverno/pkg/config"
 	controller "github.com/nirmata/kyverno/pkg/controller"
 	client "github.com/nirmata/kyverno/pkg/dclient"
 	event "github.com/nirmata/kyverno/pkg/event"
@@ -18,45 +19,45 @@ var (
 )
 
 func main() {
-	printVersionInfo()
+	defer glog.Flush()
 
+	printVersionInfo()
 	clientConfig, err := createClientConfig(kubeconfig)
 	if err != nil {
-		log.Fatalf("Error building kubeconfig: %v\n", err)
+		glog.Fatalf("Error building kubeconfig: %v\n", err)
 	}
 
-	client, err := client.NewClient(clientConfig, nil)
+	client, err := client.NewClient(clientConfig)
 	if err != nil {
-		log.Fatalf("Error creating client: %v\n", err)
+		glog.Fatalf("Error creating client: %v\n", err)
 	}
 
 	policyInformerFactory, err := sharedinformer.NewSharedInformerFactory(clientConfig)
 	if err != nil {
-		log.Fatalf("Error creating policy sharedinformer: %v\n", err)
+		glog.Fatalf("Error creating policy sharedinformer: %v\n", err)
 	}
-	eventController := event.NewEventController(client, policyInformerFactory, nil)
-	violationBuilder := violation.NewPolicyViolationBuilder(client, policyInformerFactory, eventController, nil)
+	eventController := event.NewEventController(client, policyInformerFactory)
+	violationBuilder := violation.NewPolicyViolationBuilder(client, policyInformerFactory, eventController)
 
 	policyController := controller.NewPolicyController(
 		client,
 		policyInformerFactory,
 		violationBuilder,
-		eventController,
-		nil)
+		eventController)
 
 	tlsPair, err := initTlsPemPair(clientConfig, client)
 	if err != nil {
-		log.Fatalf("Failed to initialize TLS key/certificate pair: %v\n", err)
+		glog.Fatalf("Failed to initialize TLS key/certificate pair: %v\n", err)
 	}
 
-	server, err := webhooks.NewWebhookServer(client, tlsPair, policyInformerFactory, nil)
+	server, err := webhooks.NewWebhookServer(client, tlsPair, policyInformerFactory)
 	if err != nil {
-		log.Fatalf("Unable to create webhook server: %v\n", err)
+		glog.Fatalf("Unable to create webhook server: %v\n", err)
 	}
 
 	webhookRegistrationClient, err := webhooks.NewWebhookRegistrationClient(clientConfig, client)
 	if err != nil {
-		log.Fatalf("Unable to register admission webhooks on cluster: %v\n", err)
+		glog.Fatalf("Unable to register admission webhooks on cluster: %v\n", err)
 	}
 
 	stopCh := signals.SetupSignalHandler()
@@ -65,11 +66,11 @@ func main() {
 	eventController.Run(stopCh)
 
 	if err = policyController.Run(stopCh); err != nil {
-		log.Fatalf("Error running PolicyController: %v\n", err)
+		glog.Fatalf("Error running PolicyController: %v\n", err)
 	}
 
 	if err = webhookRegistrationClient.Register(); err != nil {
-		log.Fatalf("Failed registering Admission Webhooks: %v\n", err)
+		glog.Fatalf("Failed registering Admission Webhooks: %v\n", err)
 	}
 
 	server.RunAsync()
@@ -80,5 +81,6 @@ func main() {
 
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	config.LogDefaultFlags()
 	flag.Parse()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "flag"
+
 const (
 	// These constants MUST be equal to the corresponding names in service definition in definitions/install.yaml
 	KubePolicyNamespace = "kyverno"
@@ -47,3 +49,10 @@ var (
 		"StatefulSet",
 	}
 )
+
+//LogDefaults sets default glog flags
+func LogDefaultFlags() {
+	flag.Set("logtostderr", "true")
+	flag.Set("stderrthreshold", "WARNING")
+	flag.Set("v", "2")
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -7,7 +7,7 @@ import (
 )
 
 // As the logic to process the policies in stateless, we do not need to define struct and implement behaviors for it
-// Instead we expose them as standalone functions passing the logger and the required atrributes
+// Instead we expose them as standalone functions passing the required atrributes
 // The each function returns the changes that need to be applied on the resource
 // the caller is responsible to apply the changes to the resource
 

--- a/pkg/engine/generation.go
+++ b/pkg/engine/generation.go
@@ -2,15 +2,15 @@ package engine
 
 import (
 	"fmt"
-	"log"
 
+	"github.com/golang/glog"
 	kubepolicy "github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"
 	client "github.com/nirmata/kyverno/pkg/dclient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Generate should be called to process generate rules on the resource
-func Generate(client *client.Client, logger *log.Logger, policy kubepolicy.Policy, rawResource []byte, gvk metav1.GroupVersionKind) {
+func Generate(client *client.Client, policy kubepolicy.Policy, rawResource []byte, gvk metav1.GroupVersionKind) {
 	// configMapGenerator and secretGenerator can be applied only to namespaces
 	// TODO: support for any resource
 	if gvk.Kind != "Namespace" {
@@ -21,13 +21,13 @@ func Generate(client *client.Client, logger *log.Logger, policy kubepolicy.Polic
 		ok := ResourceMeetsDescription(rawResource, rule.ResourceDescription, gvk)
 
 		if !ok {
-			logger.Printf("Rule is not applicable to the request: rule name = %s in policy %s \n", rule.Name, policy.ObjectMeta.Name)
+			glog.Infof("Rule is not applicable to the request: rule name = %s in policy %s \n", rule.Name, policy.ObjectMeta.Name)
 			continue
 		}
 
 		err := applyRuleGenerator(client, rawResource, rule.Generation, gvk)
 		if err != nil {
-			logger.Printf("Failed to apply rule generator: %v", err)
+			glog.Warningf("Failed to apply rule generator: %v", err)
 		}
 	}
 }
@@ -54,7 +54,6 @@ func applyRuleGenerator(client *client.Client, rawResource []byte, generator *ku
 	if err != nil {
 		return fmt.Errorf("Unable to apply generator for %s '%s/%s' : %v", generator.Kind, namespace, generator.Name, err)
 	}
-
-	log.Printf("Successfully applied generator %s/%s", generator.Kind, generator.Name)
+	glog.Infof("Successfully applied generator %s/%s", generator.Kind, generator.Name)
 	return nil
 }

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -1,8 +1,7 @@
 package engine
 
 import (
-	"log"
-
+	"github.com/golang/glog"
 	kubepolicy "github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -22,7 +21,7 @@ func Mutate(policy kubepolicy.Policy, rawResource []byte, gvk metav1.GroupVersio
 
 		ok := ResourceMeetsDescription(rawResource, rule.ResourceDescription, gvk)
 		if !ok {
-			log.Printf("Rule \"%s\" is not applicable to resource\n", rule.Name)
+			glog.Infof("Rule \"%s\" is not applicable to resource\n", rule.Name)
 			continue
 		}
 
@@ -31,7 +30,7 @@ func Mutate(policy kubepolicy.Policy, rawResource []byte, gvk metav1.GroupVersio
 		if rule.Mutation.Overlay != nil {
 			overlayPatches, err := ProcessOverlay(policy, rawResource, gvk)
 			if err != nil {
-				log.Printf("Overlay application has failed for rule %s in policy %s, err: %v\n", rule.Name, policy.ObjectMeta.Name, err)
+				glog.Warningf("Overlay application has failed for rule %s in policy %s, err: %v\n", rule.Name, policy.ObjectMeta.Name, err)
 			} else {
 				policyPatches = append(policyPatches, overlayPatches...)
 			}
@@ -42,7 +41,7 @@ func Mutate(policy kubepolicy.Policy, rawResource []byte, gvk metav1.GroupVersio
 		if rule.Mutation.Patches != nil {
 			processedPatches, patchedDocument, err = ProcessPatches(rule.Mutation.Patches, patchedDocument)
 			if err != nil {
-				log.Printf("Patches application has failed for rule %s in policy %s, err: %v\n", rule.Name, policy.ObjectMeta.Name, err)
+				glog.Warningf("Patches application has failed for rule %s in policy %s, err: %v\n", rule.Name, policy.ObjectMeta.Name, err)
 			} else {
 				policyPatches = append(policyPatches, processedPatches...)
 			}

--- a/pkg/engine/overlay.go
+++ b/pkg/engine/overlay.go
@@ -3,11 +3,11 @@ package engine
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"reflect"
 	"strconv"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/golang/glog"
 
 	kubepolicy "github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +28,7 @@ func ProcessOverlay(policy kubepolicy.Policy, rawResource []byte, gvk metav1.Gro
 
 		ok := ResourceMeetsDescription(rawResource, rule.ResourceDescription, gvk)
 		if !ok {
-			log.Printf("Rule \"%s\" is not applicable to resource\n", rule.Name)
+			glog.Infof("Rule \"%s\" is not applicable to resource\n", rule.Name)
 			continue
 		}
 

--- a/pkg/engine/patches.go
+++ b/pkg/engine/patches.go
@@ -3,9 +3,9 @@ package engine
 import (
 	"encoding/json"
 	"errors"
-	"log"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/golang/glog"
 	kubepolicy "github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"
 )
 
@@ -32,7 +32,7 @@ func ProcessPatches(patches []kubepolicy.Patch, resource []byte) ([]PatchBytes, 
 			if patch.Operation == "remove" {
 				continue
 			}
-			log.Printf("Patch failed: patch number = %d, patch Operation = %s, err: %v", i, patch.Operation, err)
+			glog.Warningf("Patch failed: patch number = %d, patch Operation = %s, err: %v", i, patch.Operation, err)
 			continue
 		}
 

--- a/pkg/engine/pattern.go
+++ b/pkg/engine/pattern.go
@@ -2,11 +2,12 @@ package engine
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/golang/glog"
 
 	"github.com/minio/minio/pkg/wildcard"
 )
@@ -35,7 +36,7 @@ func ValidateValueWithPattern(value, pattern interface{}) bool {
 	case bool:
 		typedValue, ok := value.(bool)
 		if !ok {
-			log.Printf("Expected bool, found %T", value)
+			glog.Warningf("Expected bool, found %T", value)
 			return false
 		}
 		return typedPattern == typedValue
@@ -50,10 +51,10 @@ func ValidateValueWithPattern(value, pattern interface{}) bool {
 	case nil:
 		return validateValueWithNilPattern(value)
 	case map[string]interface{}, []interface{}:
-		log.Println("Maps and arrays as patterns are not supported")
+		glog.Warning("Maps and arrays as patterns are not supported")
 		return false
 	default:
-		log.Printf("Unknown type as pattern: %T\n", pattern)
+		glog.Warningf("Unknown type as pattern: %T\n", pattern)
 		return false
 	}
 }
@@ -70,10 +71,10 @@ func validateValueWithIntPattern(value interface{}, pattern int64) bool {
 			return int64(typedValue) == pattern
 		}
 
-		log.Printf("Expected int, found float: %f\n", typedValue)
+		glog.Warningf("Expected int, found float: %f\n", typedValue)
 		return false
 	default:
-		log.Printf("Expected int, found: %T\n", value)
+		glog.Warningf("Expected int, found: %T\n", value)
 		return false
 	}
 }
@@ -86,12 +87,12 @@ func validateValueWithFloatPattern(value interface{}, pattern float64) bool {
 			return int(pattern) == value
 		}
 
-		log.Printf("Expected float, found int: %d\n", typedValue)
+		glog.Warningf("Expected float, found int: %d\n", typedValue)
 		return false
 	case float64:
 		return typedValue == pattern
 	default:
-		log.Printf("Expected float, found: %T\n", value)
+		glog.Warningf("Expected float, found: %T\n", value)
 		return false
 	}
 }
@@ -111,10 +112,10 @@ func validateValueWithNilPattern(value interface{}) bool {
 	case nil:
 		return true
 	case map[string]interface{}, []interface{}:
-		log.Println("Maps and arrays could not be checked with nil pattern")
+		glog.Warningf("Maps and arrays could not be checked with nil pattern")
 		return false
 	default:
-		log.Printf("Unknown type as value when checking for nil pattern: %T\n", value)
+		glog.Warningf("Unknown type as value when checking for nil pattern: %T\n", value)
 		return false
 	}
 }
@@ -147,7 +148,7 @@ func validateString(value interface{}, pattern string, operator Operator) bool {
 	if NotEqual == operator || Equal == operator {
 		strValue, ok := value.(string)
 		if !ok {
-			log.Printf("Expected string, found %T\n", value)
+			glog.Warningf("Expected string, found %T\n", value)
 			return false
 		}
 
@@ -160,7 +161,7 @@ func validateString(value interface{}, pattern string, operator Operator) bool {
 		return wildcardResult
 	}
 
-	log.Println("Operators >, >=, <, <= are not applicable to strings")
+	glog.Warningf("Operators >, >=, <, <= are not applicable to strings")
 	return false
 }
 
@@ -168,13 +169,13 @@ func validateNumberWithStr(value interface{}, patternNumber, patternStr string, 
 	if "" != patternStr {
 		typedValue, ok := value.(string)
 		if !ok {
-			log.Printf("Number must have suffix: %s", patternStr)
+			glog.Warningf("Number must have suffix: %s", patternStr)
 			return false
 		}
 
 		valueNumber, valueStr := getNumberAndStringPartsFromPattern(typedValue)
 		if !wildcard.Match(patternStr, valueStr) {
-			log.Printf("Suffix %s has not passed wildcard check: %s", valueStr, patternStr)
+			glog.Warningf("Suffix %s has not passed wildcard check: %s", valueStr, patternStr)
 			return false
 		}
 

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -3,8 +3,8 @@ package engine
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
+	"github.com/golang/glog"
 	kubepolicy "github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,7 +25,7 @@ func Validate(policy kubepolicy.Policy, rawResource []byte, gvk metav1.GroupVers
 
 		ok := ResourceMeetsDescription(rawResource, rule.ResourceDescription, gvk)
 		if !ok {
-			log.Printf("Rule \"%s\" is not applicable to resource\n", rule.Name)
+			glog.Infof("Rule \"%s\" is not applicable to resource\n", rule.Name)
 			continue
 		}
 

--- a/pkg/kyverno/apply/apply.go
+++ b/pkg/kyverno/apply/apply.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/golang/glog"
 	kubepolicy "github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"
 	"github.com/nirmata/kyverno/pkg/engine"
 	"github.com/spf13/cobra"
@@ -29,9 +30,9 @@ func NewCmdApply(in io.Reader, out, errout io.Writer) *cobra.Command {
 		Short:   "Apply policy on the resource(s)",
 		Example: applyExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			defer glog.Flush()
 			var output string
 			policy, resources := complete(args)
-
 			for _, resource := range resources {
 				patchedDocument, err := applyPolicy(policy, resource.rawResource, resource.gvk)
 				if err != nil {

--- a/pkg/violation/builder.go
+++ b/pkg/violation/builder.go
@@ -2,9 +2,8 @@ package violation
 
 import (
 	"fmt"
-	"log"
-	"os"
 
+	"github.com/golang/glog"
 	types "github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"
 	v1alpha1 "github.com/nirmata/kyverno/pkg/client/listers/policy/v1alpha1"
 	client "github.com/nirmata/kyverno/pkg/dclient"
@@ -23,7 +22,6 @@ type builder struct {
 	client       *client.Client
 	policyLister v1alpha1.PolicyLister
 	eventBuilder event.Generator
-	logger       *log.Logger
 }
 
 //Builder is to build policy violations
@@ -36,18 +34,12 @@ type Builder interface {
 //NewPolicyViolationBuilder returns new violation builder
 func NewPolicyViolationBuilder(client *client.Client,
 	sharedInfomer sharedinformer.PolicyInformer,
-	eventController event.Generator,
-	logger *log.Logger) Builder {
-
-	if logger == nil {
-		logger = log.New(os.Stdout, "Violation Builder: ", log.LstdFlags)
-	}
+	eventController event.Generator) Builder {
 
 	builder := &builder{
 		client:       client,
 		policyLister: sharedInfomer.GetLister(),
 		eventBuilder: eventController,
-		logger:       logger,
 	}
 	return builder
 }
@@ -81,7 +73,7 @@ func (b *builder) processViolation(info Info) error {
 			continue
 		}
 		if !ok {
-			b.logger.Printf("removed violation")
+			glog.Info("removed violation")
 		}
 	}
 	// If violation already exists for this rule, we update the violation


### PR DESCRIPTION
Initial revision to introduce glog as logger

Changes:
- Replace log.logger interface with glog
- glog used global logging, so no logger is to be passed to components
- Default flags for controller and cli
- not passing logger instance to http.Server. It will use go log pkg to print internal errors

To-do:
- CLI use of glog
- define guidelines for verbosity levels
- Developers to update the code as per the guidelines 