### PR TITLE
update namespace trigger + update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,14 @@ spec:
       selector:
         matchExpressions:
         - {key: kafka, operator: Exists}
-    generate:
+    generate: 
       kind: ConfigMap
       name: zk-kafka-address
       data:
-        ZK_ADDRESS: "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
-        KAFKA_ADDRESS: "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092"
+        kind: ConfigMap
+        data:
+          ZK_ADDRESS: "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
+          KAFKA_ADDRESS: "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092"
 ````
 
 ### 4. More examples

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -102,13 +102,10 @@ spec:
                     required:
                     - kind
                     - name
-                    - namespace                    
                     properties:
                       kind:
                         type: string
                       name:
-                        type: string
-                      namespace:
                         type: string
                       clone: 
                         type: object

--- a/examples/generate/policy_generate.yaml
+++ b/examples/generate/policy_generate.yaml
@@ -14,21 +14,21 @@ spec:
     generate :
       kind: ConfigMap
       name : copied-cm
-      copyFrom :
+      clone:
         namespace : default
         name : game-config
-      data :
-        secretData: "data from cmg"
   - name: "zk-kafka-address"
-    resource:
+    resource: 
       kinds:
-        - Namespace
+       - Namespace
       selector:
-        matchExpressions:
+       matchExpressions:
         - {key: LabelForSelector, operator: In, values: [namespace2]}
-    generate:
+    generate: 
       kind: ConfigMap
       name: zk-kafka-address
       data:
-        ZK_ADDRESS: "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
-        KAFKA_ADDRESS: "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092"
+        kind: ConfigMap
+        data:
+          ZK_ADDRESS: "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
+          KAFKA_ADDRESS: "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092"

--- a/examples/generate/policy_networkPolicy.yaml
+++ b/examples/generate/policy_networkPolicy.yaml
@@ -1,0 +1,24 @@
+apiVersion: kyverno.io/v1alpha1
+kind: Policy
+metadata:
+  name: "default"
+spec:
+  rules:
+  - name: "deny-all-traffic"
+    resource: 
+      kinds:
+       - Namespace
+      name: "*"
+    generate: 
+      kind: NetworkPolicy
+      name: deny-all-traffic
+      data:
+        spec:
+        podSelector:
+          matchLabels: {}
+          matchExpressions: []
+        policyTypes: []
+        metadata:
+          annotations: {}
+          labels:
+            policyname: "default"

--- a/pkg/apis/policy/v1alpha1/types.go
+++ b/pkg/apis/policy/v1alpha1/types.go
@@ -61,11 +61,10 @@ type Validation struct {
 
 // Generation describes which resources will be created when other resource is created
 type Generation struct {
-	Kind      string      `json:"kind"`
-	Name      string      `json:"name"`
-	Namespace string      `json:"namespace"`
-	Data      interface{} `json:"data"`
-	Clone     *CloneFrom  `json:"clone"`
+	Kind  string      `json:"kind"`
+	Name  string      `json:"name"`
+	Data  interface{} `json:"data"`
+	Clone *CloneFrom  `json:"clone"`
 }
 
 // CloneFrom - location of a Secret or a ConfigMap

--- a/pkg/engine/generation.go
+++ b/pkg/engine/generation.go
@@ -46,6 +46,6 @@ func applyRuleGenerator(client *client.Client, rawResource []byte, generator *ku
 	if err != nil {
 		return fmt.Errorf("Unable to apply generator for %s '%s/%s' : %v", generator.Kind, namespace, generator.Name, err)
 	}
-	glog.Infof("Successfully applied generator %s/%s", generator.Kind, generator.Name)
+	glog.Infof("Successfully applied generator %s '%s/%s'", generator.Kind, namespace, generator.Name)
 	return nil
 }

--- a/test/ConfigMapGenerator-SecretGenerator/policy-cm-test.yaml
+++ b/test/ConfigMapGenerator-SecretGenerator/policy-cm-test.yaml
@@ -14,8 +14,6 @@ spec:
     generate :
       kind: ConfigMap
       name : copied-cm
-      copyFrom :
+      clone:
         namespace : default
         name : game-config
-      data :
-        secretData: "data from cmg"

--- a/test/ConfigMapGenerator-SecretGenerator/policy-namespace-patch-cmgCG-sgCG.yaml
+++ b/test/ConfigMapGenerator-SecretGenerator/policy-namespace-patch-cmgCG-sgCG.yaml
@@ -32,11 +32,9 @@ spec :
     generate :
       kind: ConfigMap
       name : copied-cm
-      copyFrom :
+      clone:
         namespace : default
         name : game-config
-      data :
-        secretData: "data from cmg"
        
   - name: "generateCM"
     resource :
@@ -49,13 +47,13 @@ spec :
       kind: ConfigMap
       name : generated-cm
       data :
-        secretData: "very sensitive data from cmg"
-        database: mongodb
-        database_uri: mongodb://localhost:27017
-  
-        keys: | 
-          image.public.key=771 
-          rsa.public.key=42
+        data:
+          secretData: "very sensitive data from cmg"
+          database: mongodb
+          database_uri: mongodb://localhost:27017  
+          keys: | 
+            image.public.key=771 
+            rsa.public.key=42
   
   - name: "generateSecret"
     resource :


### PR DESCRIPTION
- Update the documentation examples for generate scenario
- add a yaml to create a network policy
- rework: in previous changes, I had changed the generate namespaces to the one specified inside generate. With this commit, I have reverted the behavior, and the generated resource takes the namespace from the trigger conditions(selector or name)
- removing the check on mandatory attributes for any resource during create/data mode of generation.
- update the test examples 