### PR TITLE
171 filter logs

### DIFF
--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -176,6 +176,7 @@ spec:
       containers:
         - name: kyverno
           image: nirmata/kyverno:latest
+          args: ["--filterKind","Nodes,Events,APIService,SubjectAccessReview"]
           ports:
           - containerPort: 443
           securityContext:

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -126,6 +126,11 @@ To run controller in this mode you should prepare TLS key/certificate pair for d
 The [Kyverno CLI](documentation/testing-policies.md#test-using-the-kyverno-cli) allows you to write and test policies without installing Kyverno in a Kubernetes cluster. Some features are not supported without a Kubernetes cluster.
 
 
+# Filter kuberenetes resources that admission webhook should not process
+
+The admission webhook checks if a policy is applicable on all admission requests. The kubernetes kinds that are not be processed can be filtered by using the command line argument 'filterKind'. 
+
+By default we have specified Nodes, Events, APIService & SubjectAccessReview as the kinds to be skipped in the [install.yaml](https://github.com/nirmata/kyverno/raw/master/definitions/install.yaml).
 
 ---
 <small>*Read Next >> [Writing Policies](/documentation/writing-policies.md)*</small>

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/nirmata/kyverno/pkg/config"
@@ -15,8 +16,9 @@ import (
 )
 
 var (
-	kubeconfig string
-	serverIP   string
+	kubeconfig    string
+	serverIP      string
+	filterK8Kinds arrayFlags
 )
 
 func main() {
@@ -51,7 +53,7 @@ func main() {
 		glog.Fatalf("Failed to initialize TLS key/certificate pair: %v\n", err)
 	}
 
-	server, err := webhooks.NewWebhookServer(client, tlsPair, policyInformerFactory)
+	server, err := webhooks.NewWebhookServer(client, tlsPair, policyInformerFactory, filterK8Kinds)
 	if err != nil {
 		glog.Fatalf("Unable to create webhook server: %v\n", err)
 	}
@@ -80,9 +82,24 @@ func main() {
 	policyController.Stop()
 }
 
+type arrayFlags []string
+
+func (i *arrayFlags) String() string {
+	var sb strings.Builder
+	for _, str := range *i {
+		sb.WriteString(str)
+	}
+	return sb.String()
+}
+
+func (i *arrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")
+	flag.Var(&filterK8Kinds, "filterKind", "k8 kinds where polcies are not to be applied on")
 	config.LogDefaultFlags()
 	flag.Parse()
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"strings"
 
 	"github.com/golang/glog"
 	"github.com/nirmata/kyverno/pkg/config"
@@ -18,7 +17,7 @@ import (
 var (
 	kubeconfig    string
 	serverIP      string
-	filterK8Kinds arrayFlags
+	filterK8Kinds webhooks.ArrayFlags
 )
 
 func main() {
@@ -52,7 +51,6 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Failed to initialize TLS key/certificate pair: %v\n", err)
 	}
-
 	server, err := webhooks.NewWebhookServer(client, tlsPair, policyInformerFactory, filterK8Kinds)
 	if err != nil {
 		glog.Fatalf("Unable to create webhook server: %v\n", err)
@@ -82,24 +80,10 @@ func main() {
 	policyController.Stop()
 }
 
-type arrayFlags []string
-
-func (i *arrayFlags) String() string {
-	var sb strings.Builder
-	for _, str := range *i {
-		sb.WriteString(str)
-	}
-	return sb.String()
-}
-
-func (i *arrayFlags) Set(value string) error {
-	*i = append(*i, value)
-	return nil
-}
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")
-	flag.Var(&filterK8Kinds, "filterKind", "k8 kinds where polcies are not to be applied on")
+	flag.Var(&filterK8Kinds, "filterKind", "k8 kind where policy is not evaluated by the admission webhook. example --filterKind \"Event\" --filterKind \"TokenReview,ClusterRole\"")
 	config.LogDefaultFlags()
 	flag.Parse()
 }

--- a/pkg/webhooks/utils.go
+++ b/pkg/webhooks/utils.go
@@ -1,0 +1,45 @@
+package webhooks
+
+import (
+	"strings"
+)
+
+//StringInSlice checks if string is present in slice of strings
+func StringInSlice(kind string, list []string) bool {
+	for _, b := range list {
+		if b == kind {
+			return true
+		}
+	}
+	return false
+}
+
+//parseKinds parses the kinds if a single string contains comma seperated kinds
+// {"1,2,3","4","5"} => {"1","2","3","4","5"}
+func parseKinds(list []string) []string {
+	kinds := []string{}
+	for _, k := range list {
+		args := strings.Split(k, ",")
+		for _, arg := range args {
+			if arg != "" {
+				kinds = append(kinds, strings.TrimSpace(arg))
+			}
+		}
+	}
+	return kinds
+}
+
+type ArrayFlags []string
+
+func (i *ArrayFlags) String() string {
+	var sb strings.Builder
+	for _, str := range *i {
+		sb.WriteString(str)
+	}
+	return sb.String()
+}
+
+func (i *ArrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}

--- a/pkg/webhooks/utils.go
+++ b/pkg/webhooks/utils.go
@@ -2,6 +2,8 @@ package webhooks
 
 import (
 	"strings"
+
+	"github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"
 )
 
 //StringInSlice checks if string is present in slice of strings
@@ -42,4 +44,22 @@ func (i *ArrayFlags) String() string {
 func (i *ArrayFlags) Set(value string) error {
 	*i = append(*i, value)
 	return nil
+}
+
+// extract the kinds that the policy rules apply to
+func getApplicableKindsForPolicy(p *v1alpha1.Policy) []string {
+	kindsMap := map[string]interface{}{}
+	kinds := []string{}
+	// iterate over the rules an identify all kinds
+	for _, rule := range p.Spec.Rules {
+		for _, k := range rule.ResourceDescription.Kinds {
+			kindsMap[k] = nil
+		}
+	}
+
+	// get the kinds
+	for k := range kindsMap {
+		kinds = append(kinds, k)
+	}
+	return kinds
 }


### PR DESCRIPTION
Issue: #171 
Introduce command line argument "filterKind", to allow the user to specify the Kinds that are to be filtered while processing policies at admission webhook.

k8 kind where policy is not evaluated by the admission webhook. example --filterKind "Event" --filterKind "TokenReview","ClusterRole"