### PR TITLE
resource patched after every rule + rm PatchBytes

### DIFF
--- a/pkg/engine/patches.go
+++ b/pkg/engine/patches.go
@@ -10,12 +10,9 @@ import (
 	kubepolicy "github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"
 )
 
-// PatchBytes stands for []byte
-type PatchBytes []byte
-
 // ProcessPatches Returns array from separate patches that can be applied to the document
 // Returns error ONLY in case when creation of resource should be denied.
-func ProcessPatches(rule kubepolicy.Rule, resource []byte) (allPatches []PatchBytes, errs []error) {
+func ProcessPatches(rule kubepolicy.Rule, resource []byte) (allPatches [][]byte, errs []error) {
 	if len(resource) == 0 {
 		errs = append(errs, errors.New("Source document for patching is empty"))
 		return nil, errs
@@ -48,8 +45,8 @@ func ProcessPatches(rule kubepolicy.Rule, resource []byte) (allPatches []PatchBy
 }
 
 // JoinPatches joins array of serialized JSON patches to the single JSONPatch array
-func JoinPatches(patches []PatchBytes) PatchBytes {
-	var result PatchBytes
+func JoinPatches(patches [][]byte) []byte {
+	var result []byte
 	if len(patches) == 0 {
 		return result
 	}
@@ -67,12 +64,12 @@ func JoinPatches(patches []PatchBytes) PatchBytes {
 
 // applyPatch applies patch for resource, returns patched resource.
 func applyPatch(resource []byte, patchRaw []byte) ([]byte, error) {
-	patchesList := []PatchBytes{patchRaw}
+	patchesList := [][]byte{patchRaw}
 	return ApplyPatches(resource, patchesList)
 }
 
 // ApplyPatches patches given resource with given patches and returns patched document
-func ApplyPatches(resource []byte, patches []PatchBytes) ([]byte, error) {
+func ApplyPatches(resource []byte, patches [][]byte) ([]byte, error) {
 	joinedPatches := JoinPatches(patches)
 	patch, err := jsonpatch.DecodePatch(joinedPatches)
 	if err != nil {

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -153,7 +153,7 @@ func (ws *WebhookServer) HandleMutation(request *v1beta1.AdmissionRequest) *v1be
 		}
 	}
 
-	var allPatches []engine.PatchBytes
+	var allPatches [][]byte
 	policyInfos := []*info.PolicyInfo{}
 	for _, policy := range policies {
 		// check if policy has a rule for the admission request kind
@@ -389,6 +389,7 @@ func (ws *WebhookServer) bodyToAdmissionReview(request *http.Request, writer htt
 	return admissionReview
 }
 
+//HandlePolicyValidation performs the validation check on policy resource
 func (ws *WebhookServer) HandlePolicyValidation(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
 	return ws.validateUniqueRuleName(request.Object.Raw)
 }
@@ -410,9 +411,8 @@ func (ws *WebhookServer) validateUniqueRuleName(rawPolicy []byte) *v1beta1.Admis
 					Message: msg,
 				},
 			}
-		} else {
-			ruleNames = append(ruleNames, rule.Name)
 		}
+		ruleNames = append(ruleNames, rule.Name)
 	}
 
 	glog.V(3).Infof("Policy validation passed.")


### PR DESCRIPTION
Changes:
- patch the resource after every rule
- mutation rules operated on the patched resource while processing the rule
- the actual JSON patch if all rules succeed is done by passing the patches to the response.
Resolves #157 
Removal:
- removed type PatchBytes, as the type didn't have methods associated with it. 
- we would remove the common components into pkg/utils, and not typing it with allow us to not have cyclic dependencies and keep types across packages simple
