### PR TITLE
get resource using kind & add cache invalidate mechanism and retry

### DIFF
--- a/pkg/dclient/client_test.go
+++ b/pkg/dclient/client_test.go
@@ -64,32 +64,32 @@ func newFixture(t *testing.T) *fixture {
 func TestCRUDResource(t *testing.T) {
 	f := newFixture(t)
 	// Get Resource
-	_, err := f.client.GetResource("thekinds", "ns-foo", "name-foo")
+	_, err := f.client.GetResource("thekind", "ns-foo", "name-foo")
 	if err != nil {
 		t.Errorf("GetResource not working: %s", err)
 	}
 	// List Resources
-	_, err = f.client.ListResource("thekinds", "ns-foo", nil)
+	_, err = f.client.ListResource("thekind", "ns-foo", nil)
 	if err != nil {
 		t.Errorf("ListResource not working: %s", err)
 	}
 	// DeleteResouce
-	err = f.client.DeleteResouce("thekinds", "ns-foo", "name-bar", false)
+	err = f.client.DeleteResouce("thekind", "ns-foo", "name-bar", false)
 	if err != nil {
 		t.Errorf("DeleteResouce not working: %s", err)
 	}
 	// CreateResource
-	_, err = f.client.CreateResource("thekinds", "ns-foo", newUnstructured("group/version", "TheKind", "ns-foo", "name-foo1"), false)
+	_, err = f.client.CreateResource("thekind", "ns-foo", newUnstructured("group/version", "TheKind", "ns-foo", "name-foo1"), false)
 	if err != nil {
 		t.Errorf("CreateResource not working: %s", err)
 	}
 	//	UpdateResource
-	_, err = f.client.UpdateResource("thekinds", "ns-foo", newUnstructuredWithSpec("group/version", "TheKind", "ns-foo", "name-foo1", map[string]interface{}{"foo": "bar"}), false)
+	_, err = f.client.UpdateResource("thekind", "ns-foo", newUnstructuredWithSpec("group/version", "TheKind", "ns-foo", "name-foo1", map[string]interface{}{"foo": "bar"}), false)
 	if err != nil {
 		t.Errorf("UpdateResource not working: %s", err)
 	}
 	// UpdateStatusResource
-	_, err = f.client.UpdateStatusResource("thekinds", "ns-foo", newUnstructuredWithSpec("group/version", "TheKind", "ns-foo", "name-foo1", map[string]interface{}{"foo": "status"}), false)
+	_, err = f.client.UpdateStatusResource("thekind", "ns-foo", newUnstructuredWithSpec("group/version", "TheKind", "ns-foo", "name-foo1", map[string]interface{}{"foo": "status"}), false)
 	if err != nil {
 		t.Errorf("UpdateStatusResource not working: %s", err)
 	}
@@ -124,7 +124,7 @@ func TestGenerateResource(t *testing.T) {
 	// 1 create namespace
 	// 2 generate resource
 	// create namespace
-	ns, err := f.client.CreateResource("namespaces", "", newUnstructured("v1", "Namespace", "", "ns1"), false)
+	ns, err := f.client.CreateResource("Namespace", "", newUnstructured("v1", "Namespace", "", "ns1"), false)
 	if err != nil {
 		t.Errorf("CreateResource not working: %s", err)
 	}
@@ -135,7 +135,7 @@ func TestGenerateResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("GenerateResource not working: %s", err)
 	}
-	_, err = f.client.GetResource("thekinds", "ns1", "gen-kind")
+	_, err = f.client.GetResource("TheKind", "ns1", "gen-kind")
 	if err != nil {
 		t.Errorf("GetResource not working: %s", err)
 	}
@@ -147,7 +147,7 @@ func TestGenerateResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("GenerateResource not working: %s", err)
 	}
-	_, err = f.client.GetResource("thekinds", "ns1", "name2-baz-new")
+	_, err = f.client.GetResource("TheKind", "ns1", "name2-baz-new")
 	if err != nil {
 		t.Errorf("GetResource not working: %s", err)
 	}

--- a/pkg/dclient/utils.go
+++ b/pkg/dclient/utils.go
@@ -12,14 +12,15 @@ import (
 )
 
 const (
-	//CSRs certificatesigningrequests
-	CSRs string = "certificatesigningrequests"
-	// Secrets secrets
-	Secrets string = "secrets"
-	// ConfigMaps configmaps
-	ConfigMaps string = "configmaps"
-	// Namespaces namespaces
-	Namespaces string = "namespaces"
+	// Kind names are case sensitive
+	//CSRs CertificateSigningRequest
+	CSRs string = "CertificateSigningRequest"
+	// Secrets Secret
+	Secrets string = "Secret"
+	// ConfigMaps ConfigMap
+	ConfigMaps string = "ConfigMap"
+	// Namespaces Namespace
+	Namespaces string = "Namespace"
 )
 const namespaceCreationMaxWaitTime time.Duration = 30 * time.Second
 const namespaceCreationWaitInterval time.Duration = 100 * time.Millisecond

--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -139,8 +139,7 @@ func (c *controller) SyncHandler(key Info) error {
 			return err
 		}
 	default:
-		resource := c.client.DiscoveryClient.GetGVRFromKind(key.Kind).Resource
-		robj, err = c.client.GetResource(resource, key.Namespace, key.Name)
+		robj, err = c.client.GetResource(key.Kind, key.Namespace, key.Name)
 		if err != nil {
 			glog.Errorf("unable to create event for resource %s, will retry ", key.Namespace+"/"+key.Name)
 			return err

--- a/pkg/gencontroller/controller.go
+++ b/pkg/gencontroller/controller.go
@@ -148,7 +148,6 @@ func (c *Controller) syncHandler(obj interface{}) error {
 		}
 	}
 
-	glog.Info("apply generation policy to resources :)")
 	//TODO: need to find a way to store the policy such that we can directly queury the
 	// policies with generation policies
 	// PolicyListerExpansion

--- a/pkg/testrunner/test.go
+++ b/pkg/testrunner/test.go
@@ -1,6 +1,7 @@
 package testrunner
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -41,7 +42,7 @@ func (t *test) run() {
 		// assuming its namespaces creation
 		decode := kscheme.Codecs.UniversalDeserializer().Decode
 		obj, _, err := decode([]byte(t.tResource.rawResource), nil, nil)
-		_, err = client.CreateResource(getResourceFromKind(t.tResource.gvk.Kind), "", obj, false)
+		_, err = client.CreateResource(t.tResource.gvk.Kind, "", obj, false)
 		if err != nil {
 			t.t.Errorf("error while creating namespace %s", err)
 		}
@@ -68,6 +69,8 @@ func (t *test) checkMutationResult(pr *resourceInfo, policyInfo *info.PolicyInfo
 	}
 	// patched resource
 	if !compareResource(pr, t.patchedResource) {
+		fmt.Println(string(t.patchedResource.rawResource))
+		fmt.Println(string(pr.rawResource))
 		glog.Warningf("Expected resource %s ", string(pr.rawResource))
 		t.t.Error("Patched resources not as expected")
 	}
@@ -148,7 +151,7 @@ func (t *test) checkGenerationResult(client *client.Client, policyInfo *info.Pol
 	for _, r := range t.genResources {
 		n := ParseNameFromObject(r.rawResource)
 		ns := ParseNamespaceFromObject(r.rawResource)
-		_, err := client.GetResource(getResourceFromKind(r.gvk.Kind), ns, n)
+		_, err := client.GetResource(r.gvk.Kind, ns, n)
 		if err != nil {
 			t.t.Errorf("Resource %s/%s of kinf %s not found", ns, n, r.gvk.Kind)
 		}

--- a/pkg/violation/builder.go
+++ b/pkg/violation/builder.go
@@ -55,7 +55,7 @@ func (b *builder) processViolation(info *Info) error {
 	statusMap := map[string]interface{}{}
 	var ok bool
 	//TODO: hack get from client
-	p1, err := b.client.GetResource("policies", "", info.Policy, "status")
+	p1, err := b.client.GetResource("Policy", "", info.Policy, "status")
 	if err != nil {
 		return err
 	}
@@ -106,54 +106,6 @@ func (b *builder) processViolation(info *Info) error {
 		return err
 	}
 	return nil
-	// modifiedViolations := []types.Violation{}
-	// modifiedViolations = append(modifiedViolations, types.Violation{Name: "name", Kind: "Deploymeny"})
-	// unstr["status"] = modifiedViolations
-	// p1.SetUnstructuredContent(unstr)
-	// rdata, err := p1.MarshalJSON()
-	// if err != nil {
-	// 	glog.Info(err)
-	// }
-	// glog.Info(string(rdata))
-	// _, err = b.client.UpdateStatusResource("policies", "", p1, false)
-	// if err != nil {
-	// 	glog.Info(err)
-	// }
-
-	// p, err := b.policyLister.Get(info.Policy)
-	// if err != nil {
-	// 	glog.Error(err)
-	// 	return err
-	// }
-
-	// glog.Info(p.TypeMeta.Kind)
-	// glog.Info(p.Kind)
-	// modifiedPolicy := p.DeepCopy()
-	// glog.Info(modifiedPolicy.Kind)
-	// // Create new violation
-	// newViolation := info.Violation
-
-	// for _, violation := range modifiedPolicy.Status.Violations {
-	// 	ok, err := b.isActive(info.Kind, violation.Name)
-	// 	if err != nil {
-	// 		glog.Error(err)
-	// 		continue
-	// 	}
-	// 	if !ok {
-	// 		glog.Info("removed violation")
-	// 	}
-	// }
-	// // If violation already exists for this rule, we update the violation
-	// //TODO: update violation, instead of re-creating one every time
-	// modifiedViolations = append(modifiedViolations, newViolation)
-	// modifiedPolicy.Status.Violations = modifiedViolations
-	// // Violations are part of the status sub resource, so we can use the Update Status api instead of updating the policy object
-	// _, err = b.client.UpdateStatusResource("policies", "", *modifiedPolicy, false)
-	// if err != nil {
-	// 	glog.Info(err)
-	// 	return err
-	// }
-	// return nil
 }
 
 func (b *builder) isActive(kind string, rname string, rnamespace string) (bool, error) {


### PR DESCRIPTION
Fixes partially #76

Changes:
- The dynamic client now use "Kind" as the identifier instead of the resource name
- if a kind -> resource mapping fails we invalidate the cache and retry. If it is still not found then we fail. The 2 retry mechanism is similar to mechanism used by DefaultRESTMapper.
- Fix tests accordingly
