### PR TITLE
Fixes

### DIFF
--- a/pkg/annotations/utils.go
+++ b/pkg/annotations/utils.go
@@ -12,5 +12,5 @@ func getStatus(status bool) string {
 }
 
 func BuildKey(policyName string) string {
-	return "policies.kyverno.io." + policyName
+	return "policies.kyverno.io/" + policyName
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -104,6 +104,16 @@ func mutation(p *types.Policy, rawResource []byte, gvk *metav1.GroupVersionKind)
 		// no rules were processed
 		return nil, nil
 	}
+	// if there are any errors return
+	for _, r := range ruleInfos {
+		if !r.IsSuccessful() {
+			return ruleInfos, nil
+		}
+	}
+	// if there are no patches // for overlay
+	if len(patches) == 0 {
+		return ruleInfos, nil
+	}
 	// option 2: (original Resource + patch) compare with (original resource)
 	mergePatches := JoinPatches(patches)
 	// merge the patches

--- a/pkg/webhooks/mutation.go
+++ b/pkg/webhooks/mutation.go
@@ -67,12 +67,11 @@ func (ws *WebhookServer) HandleMutation(request *v1beta1.AdmissionRequest) *v1be
 				glog.Warningf("%s: %s\n", r.Name, r.Msgs)
 			}
 		} else {
-			// TODO
-			// // CleanUp Violations if exists
-			// err := ws.violationBuilder.RemoveInactiveViolation(policy.Name, request.Kind.Kind, rns, rname, info.Validation)
-			// if err != nil {
-			// 	glog.Info(err)
-			// }
+			// CleanUp Violations if exists
+			err := ws.violationBuilder.RemoveInactiveViolation(policy.Name, request.Kind.Kind, rns, rname, info.Mutation)
+			if err != nil {
+				glog.Info(err)
+			}
 			allPatches = append(allPatches, policyPatches...)
 			glog.Infof("Mutation from policy %s has applied succesfully to %s %s/%s", policy.Name, request.Kind.Kind, rname, rns)
 		}

--- a/pkg/webhooks/utils.go
+++ b/pkg/webhooks/utils.go
@@ -167,7 +167,7 @@ func setObserverdGenerationAsZero(bytes []byte) []byte {
 	json.Unmarshal(bytes, &objectJSON)
 	status, ok := objectJSON["status"].(map[string]interface{})
 	if !ok {
-		glog.Error("status block not found, not setting observed generation")
+		// glog.Error("status block not found, not setting observed generation")
 		return bytes
 	}
 	status["observedGeneration"] = 0

--- a/pkg/webhooks/utils.go
+++ b/pkg/webhooks/utils.go
@@ -156,7 +156,8 @@ func setKindForObject(bytes []byte, kind string) []byte {
 	data, err := json.Marshal(objectJSON)
 	if err != nil {
 		glog.Error(err)
-		return nil
+		glog.Error("unable to marshall, not setting the kind")
+		return bytes
 	}
 	return data
 }
@@ -166,15 +167,16 @@ func setObserverdGenerationAsZero(bytes []byte) []byte {
 	json.Unmarshal(bytes, &objectJSON)
 	status, ok := objectJSON["status"].(map[string]interface{})
 	if !ok {
-		glog.Error("type mismatch")
+		glog.Error("status block not found, not setting observed generation")
+		return bytes
 	}
 	status["observedGeneration"] = 0
 	objectJSON["status"] = status
 	data, err := json.Marshal(objectJSON)
 	if err != nil {
 		glog.Error(err)
-		return nil
+		glog.Error("unable to marshall, not setting observed generation")
+		return bytes
 	}
 	return data
-
 }

--- a/pkg/webhooks/utils.go
+++ b/pkg/webhooks/utils.go
@@ -196,22 +196,3 @@ func setKindForObject(bytes []byte, kind string) []byte {
 	}
 	return data
 }
-
-func setObserverdGenerationAsZero(bytes []byte) []byte {
-	var objectJSON map[string]interface{}
-	json.Unmarshal(bytes, &objectJSON)
-	status, ok := objectJSON["status"].(map[string]interface{})
-	if !ok {
-		// glog.Error("status block not found, not setting observed generation")
-		return bytes
-	}
-	status["observedGeneration"] = 0
-	objectJSON["status"] = status
-	data, err := json.Marshal(objectJSON)
-	if err != nil {
-		glog.Error(err)
-		glog.Error("unable to marshall, not setting observed generation")
-		return bytes
-	}
-	return data
-}


### PR DESCRIPTION
creating annotations on the resource results in a resoure update request and this request is forwarded to handleMutatation & handleValidation, then the rules are applied on the resources and if the only mutation rules are present it patches the resource.

Updated the logic:
- we now compare the old and new annotations count by filtering on prefix "policies.kyverno.io/"
- count the old and new annotations, if there is a difference of +1 or -1, we know its annotations add and remove respectively. as we only update one at a time.
- if the number of annotations is equal, then we do an equality check to see if there is any update.
- if the above cases are satisfied we skip processing policies.