### PR TITLE
224 feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 		eventController,
 		annotationsController)
 
-	genControler := gencontroller.NewGenController(client, eventController, policyInformerFactory, violationBuilder, kubeInformer.Core().V1().Namespaces())
+	genControler := gencontroller.NewGenController(client, eventController, policyInformerFactory, violationBuilder, kubeInformer.Core().V1().Namespaces(), annotationsController)
 	tlsPair, err := initTLSPemPair(clientConfig, client)
 	if err != nil {
 		glog.Fatalf("Failed to initialize TLS key/certificate pair: %v\n", err)

--- a/pkg/engine/overlay_test.go
+++ b/pkg/engine/overlay_test.go
@@ -9,7 +9,7 @@ import (
 	"gotest.tools/assert"
 )
 
-func compareJsonAsMap(t *testing.T, expected, actual []byte) {
+func compareJSONAsMap(t *testing.T, expected, actual []byte) {
 	var expectedMap, actualMap map[string]interface{}
 	assert.NilError(t, json.Unmarshal(expected, &expectedMap))
 	assert.NilError(t, json.Unmarshal(actual, &actualMap))
@@ -106,7 +106,7 @@ func TestApplyOverlay_NestedListWithAnchor(t *testing.T) {
 		]
 	 }`)
 
-	compareJsonAsMap(t, expectedResult, patched)
+	compareJSONAsMap(t, expectedResult, patched)
 }
 
 func TestApplyOverlay_InsertIntoArray(t *testing.T) {
@@ -223,7 +223,7 @@ func TestApplyOverlay_InsertIntoArray(t *testing.T) {
 		]
 	 }`)
 
-	compareJsonAsMap(t, expectedResult, patched)
+	compareJSONAsMap(t, expectedResult, patched)
 }
 
 func TestApplyOverlay_TestInsertToArray(t *testing.T) {
@@ -428,7 +428,7 @@ func TestApplyOverlay_ImagePullPolicy(t *testing.T) {
 		}
 	 }`)
 
-	compareJsonAsMap(t, expectedResult, doc)
+	compareJSONAsMap(t, expectedResult, doc)
 }
 
 func TestApplyOverlay_AddingAnchor(t *testing.T) {
@@ -471,7 +471,7 @@ func TestApplyOverlay_AddingAnchor(t *testing.T) {
 		}
 	 }`)
 
-	compareJsonAsMap(t, expectedResult, doc)
+	compareJSONAsMap(t, expectedResult, doc)
 }
 
 func TestApplyOverlay_AddingAnchorInsideListElement(t *testing.T) {
@@ -591,5 +591,5 @@ func TestApplyOverlay_AddingAnchorInsideListElement(t *testing.T) {
 			}
 		}
 	}`)
-	compareJsonAsMap(t, expectedResult, doc)
+	compareJSONAsMap(t, expectedResult, doc)
 }

--- a/pkg/engine/utils.go
+++ b/pkg/engine/utils.go
@@ -253,6 +253,6 @@ func convertToFloat(value interface{}) (float64, error) {
 }
 
 type resourceInfo struct {
-	resource *unstructured.Unstructured
+	resource unstructured.Unstructured
 	gvk      *metav1.GroupVersionKind
 }

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -197,6 +197,7 @@ func valFromReferenceToString(value interface{}, operator string) (string, error
 	}
 }
 
+//FormAbsolutePath returns absolute path
 func FormAbsolutePath(referencePath, absolutePath string) string {
 	if filepath.IsAbs(referencePath) {
 		return referencePath

--- a/pkg/webhooks/utils.go
+++ b/pkg/webhooks/utils.go
@@ -55,6 +55,7 @@ func parseKinds(list []string) []string {
 	return kinds
 }
 
+//ArrayFlags to store filterkinds
 type ArrayFlags []string
 
 func (i *ArrayFlags) String() string {
@@ -65,6 +66,7 @@ func (i *ArrayFlags) String() string {
 	return sb.String()
 }
 
+//Set setter for array flags
 func (i *ArrayFlags) Set(value string) error {
 	*i = append(*i, value)
 	return nil


### PR DESCRIPTION
Process generation rules on an existing resource. (there is a scenario when the controller is already up, and the generation informer also has filled it cache but does not process policy as no policy is present. When the policy is created, it is not picked by generation controller, so need to process it from policy controller)
- Apply generate on the existing namespace
- Add annotations to Namespace resource
Misc:
- Go vet suggestions

fixes #224 