### PR TITLE
show mutation changes in annotation

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -62,6 +62,12 @@ func getRules(rules []*pinfo.RuleInfo, ruleType pinfo.RuleType) map[string]Rule 
 		rule := Rule{Status: getStatus(r.IsSuccessful())}
 		if !r.IsSuccessful() {
 			rule.Message = r.GetErrorString()
+		} else {
+			if ruleType == pinfo.Mutation {
+				// If ruleType is Mutation
+				// then for succesful mutation we store the json patch being applied in the annotation information
+				rule.Changes = r.Changes
+			}
 		}
 		annrules[r.Name] = rule
 	}

--- a/pkg/controller/cleanup.go
+++ b/pkg/controller/cleanup.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 	"github.com/nirmata/kyverno/pkg/annotations"
 	v1alpha1 "github.com/nirmata/kyverno/pkg/apis/policy/v1alpha1"

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -27,14 +27,18 @@ func Mutate(policy kubepolicy.Policy, rawResource []byte, gvk metav1.GroupVersio
 		// Process Overlay
 		if rule.Mutation.Overlay != nil {
 			overlayPatches, err := ProcessOverlay(rule, rawResource, gvk)
-			if err == nil { 
-				if len(overlayPatches) == 0{
+			if err == nil {
+				if len(overlayPatches) == 0 {
 					// if array elements dont match then we skip(nil patch, no error)
 					// or if acnohor is defined and doenst match
 					// policy is not applicable
 					continue
 				}
 				ri.Addf("Rule %s: Overlay succesfully applied.", rule.Name)
+				// merge the json patches
+				patch := JoinPatches(overlayPatches)
+				// strip slashes from string
+				ri.Changes = string(patch)
 				allPatches = append(allPatches, overlayPatches...)
 			} else {
 				ri.Fail()

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -113,6 +113,7 @@ func (ri RuleType) String() string {
 type RuleInfo struct {
 	Name     string
 	Msgs     []string
+	Changes  string // this will store the mutation patch being applied by the rule
 	RuleType RuleType
 	success  bool
 }


### PR DESCRIPTION
For a successful mutation rule application, we store the JSON patch used to mutate the object in annotations.

fixes #233