### PR TITLE
defaultfailureaction as 'audit'

### DIFF
--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -26,8 +26,8 @@ spec:
             validationFailureAction:
               type: string
               enum: 
-              - enforce # blocks the resorce api-reques if a rule fails. Default behavior
-              - audit # allows resource creationg and reports the failed validation rules as violations
+              - enforce # blocks the resorce api-reques if a rule fails.
+              - audit # allows resource creation and reports the failed validation rules as violations. Default
             rules:
               type: array
               items:

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -26,8 +26,8 @@ spec:
             validationFailureAction:
               type: string
               enum: 
-              - enforce # blocks the resorce api-reques if a rule fails. Default behavior
-              - audit # allows resource creationg and reports the failed validation rules as violations
+              - enforce # blocks the resorce api-reques if a rule fails.
+              - audit # allows resource creationg and reports the failed validation rules as violations. Default
             rules:
               type: array
               items:

--- a/documentation/writing-policies.md
+++ b/documentation/writing-policies.md
@@ -10,6 +10,9 @@ kind : ClusterPolicy
 metadata :
   name : policy
 spec :
+  # 'enforce' to block resource request if any rules fail
+  # 'audit' to allow resource request on failure of rules, but create policy violations to report them
+  validationFailureAction: enforce
   # Each policy has a list of rules applied in declaration order
   rules:
     # Rules must have a unique name

--- a/examples/best_practices/policy_mutate_pod_disable_automountingapicred.yaml
+++ b/examples/best_practices/policy_mutate_pod_disable_automountingapicred.yaml
@@ -1,0 +1,16 @@
+apiVersion : kyverno.io/v1alpha1
+kind: ClusterPolicy
+metadata:
+  name: mutate-pod-disable-automoutingapicred
+spec:
+  rules:
+  - name: pod-disable-automoutingapicred
+    match:
+      resources:
+        kinds:
+        - Pod
+    mutate:
+      overlay:
+        spec:
+          (serviceAccountName): "*"
+          automountServiceAccountToken: false

--- a/examples/best_practices/policy_validate_image_latest_ifnotpresent_deny.yaml
+++ b/examples/best_practices/policy_validate_image_latest_ifnotpresent_deny.yaml
@@ -1,0 +1,18 @@
+apiVersion : kyverno.io/v1alpha1
+kind: ClusterPolicy
+metadata:
+  name: validate-image
+spec:
+  rules:
+  - name: validate-tag
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "imagePullPolicy 'IfNotPresent' forbidden with image tag 'latest'"    
+      pattern:
+        spec:
+          containers:
+          - (image): "*:latest"
+            imagePullPolicy: "!IfNotPresent"

--- a/examples/best_practices/policy_validate_image_pullpolicy_notalways_deny.yaml
+++ b/examples/best_practices/policy_validate_image_pullpolicy_notalways_deny.yaml
@@ -1,0 +1,17 @@
+apiVersion : kyverno.io/v1alpha1
+kind: ClusterPolicy
+metadata:
+  name: validate-image-pullpolicy-notalways
+spec:
+  rules:
+  - name: image-pullpolicy-notalways
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "image pull policy 'Always' forbidden"  
+      pattern:
+        spec:
+          containers:
+          - imagePullPolicy: "!Always"

--- a/examples/best_practices/policy_validate_image_tag.yaml
+++ b/examples/best_practices/policy_validate_image_tag.yaml
@@ -1,0 +1,29 @@
+apiVersion : kyverno.io/v1alpha1
+kind: ClusterPolicy
+metadata:
+  name: validate-image
+spec:
+  rules:
+  - name: validate-tag
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "An image tag is required"    
+      pattern:
+        spec:
+          containers:
+          - image: "*:*"  
+  - name: validate-latest
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "imagePullPolicy 'Always' required with tag 'latest'"    
+      pattern:
+        spec:
+          containers:
+          - (image): "*latest"
+            imagePullPolicy: Always

--- a/examples/best_practices/policy_validate_image_tag_latest_deny.yaml
+++ b/examples/best_practices/policy_validate_image_tag_latest_deny.yaml
@@ -1,0 +1,17 @@
+apiVersion : kyverno.io/v1alpha1
+kind: ClusterPolicy
+metadata:
+  name: validate-image-tag-notlatest
+spec:
+  rules:
+  - name: image-tag-notlatest
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "image tag 'latest' forbidden"  
+      pattern:
+        spec:
+          containers:
+          - image: "!*:latest"

--- a/examples/best_practices/policy_validate_image_tag_notspecified_deny.yaml
+++ b/examples/best_practices/policy_validate_image_tag_notspecified_deny.yaml
@@ -1,0 +1,17 @@
+apiVersion : kyverno.io/v1alpha1
+kind: ClusterPolicy
+metadata:
+  name: validate-image-tag-notspecified
+spec:
+  rules:
+  - name: image-tag-notspecified
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "image tag not specified"  
+      pattern:
+        spec:
+          containers:
+          - image: "*:*"

--- a/examples/best_practices/policy_validate_pod_probes.yaml
+++ b/examples/best_practices/policy_validate_pod_probes.yaml
@@ -1,0 +1,25 @@
+apiVersion: kyverno.io/v1alpha1
+kind: ClusterPolicy
+metadata:
+  name: validate-probes
+spec:
+  validationFailureAction: "audit"
+  rules:
+  - name: check-probes
+    match:
+      resources:
+        kinds:
+        - Pod
+    # exclude:
+    #   namespaces:
+    #     - kube-system
+    validate:
+      message: "Liveness and readiness probes are required"
+      pattern:
+        spec:
+          containers:
+            livenessProbe:
+              periodSeconds: ">0"      
+            readinessProbe:
+              periodSeconds: ">0"
+

--- a/examples/best_practices/policy_validate_pod_resources.yaml
+++ b/examples/best_practices/policy_validate_pod_resources.yaml
@@ -1,0 +1,26 @@
+apiVersion: kyverno.io/v1alpha1
+kind: ClusterPolicy
+metadata:
+  name: check-resources
+spec:
+  # validationFailureAction: "audit"
+  rules:
+  - name: check-pod-resources
+    message: "CPU and memory resource requests and limits are required"
+    match:
+      resources:
+        kinds:
+        - Pod
+        name: myapp-pod
+    validate:
+      pattern:
+        spec:
+          containers:
+          - name: "*"
+            resources:
+              requests:
+                memory: "?*"
+                cpu: "?*"
+              limits:
+                memory: "?*"
+                cpu: "?*"

--- a/examples/best_practices/resource_default_namespace.yaml
+++ b/examples/best_practices/resource_default_namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx

--- a/examples/best_practices/resource_mutate_pod_disable_automountingapicred.yaml
+++ b/examples/best_practices/resource_mutate_pod_disable_automountingapicred.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  serviceAccountName: default
+  containers:
+  - name: nginx
+    image: nginx
+    imagePullPolicy: IfNotPresent

--- a/examples/best_practices/resource_validate_image_latest_ifnotpresent_deny.yaml
+++ b/examples/best_practices/resource_validate_image_latest_ifnotpresent_deny.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx:latest
+    imagePullPolicy: IfNotPresent

--- a/examples/best_practices/resource_validate_image_latest_ifnotpresent_pass.yaml
+++ b/examples/best_practices/resource_validate_image_latest_ifnotpresent_pass.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx:1.12
+    imagePullPolicy: IfNotPresent

--- a/examples/best_practices/resource_validate_image_pullpolicy_notalways_deny.yaml
+++ b/examples/best_practices/resource_validate_image_pullpolicy_notalways_deny.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx
+    imagePullPolicy: Always

--- a/examples/best_practices/resource_validate_image_pullpolicy_notalways_pass.yaml
+++ b/examples/best_practices/resource_validate_image_pullpolicy_notalways_pass.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx
+    imagePullPolicy: IfNotPresent

--- a/examples/best_practices/resource_validate_image_tag_latest_deny.yaml
+++ b/examples/best_practices/resource_validate_image_tag_latest_deny.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx:latest

--- a/examples/best_practices/resource_validate_image_tag_latest_pass.yaml
+++ b/examples/best_practices/resource_validate_image_tag_latest_pass.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx:1.12

--- a/examples/best_practices/resource_validate_image_tag_notspecified_deny.yaml
+++ b/examples/best_practices/resource_validate_image_tag_notspecified_deny.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx

--- a/examples/best_practices/resource_validate_image_tag_notspecified_pass.yaml
+++ b/examples/best_practices/resource_validate_image_tag_notspecified_pass.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx:latest

--- a/examples/best_practices/resource_validate_pod_resources.yaml
+++ b/examples/best_practices/resource_validate_pod_resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec: 
+  containers:
+  - name: nginx
+    image: nginx

--- a/examples/best_practices/validate_default_namespace.yaml
+++ b/examples/best_practices/validate_default_namespace.yaml
@@ -1,0 +1,18 @@
+apiVersion: kyverno.io/v1alpha1
+kind: ClusterPolicy
+metadata:
+  name: validate-namespace
+spec:
+  rules:
+  - name: check-default-namespace
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "A namespace is required"
+      anyPattern:
+        - metadata:
+            namespace: "?*"
+        - metadata:
+            namespace: "!default"

--- a/pkg/engine/response.go
+++ b/pkg/engine/response.go
@@ -25,7 +25,7 @@ type PolicyResponse struct {
 	PolicyStats `json:",inline"`
 	// rule response
 	Rules []RuleResponse `json:"rules"`
-	// ValidationFailureAction: audit,enforce(default)
+	// ValidationFailureAction: audit(default if not set),enforce
 	ValidationFailureAction string
 }
 

--- a/pkg/testrunner/testrunner_test.go
+++ b/pkg/testrunner/testrunner_test.go
@@ -33,3 +33,41 @@ func Test_validate_nonRootUsers(t *testing.T) {
 func Test_generate_networkPolicy(t *testing.T) {
 	testScenario(t, "/test/scenarios/test/scenario_generate_networkPolicy.yaml")
 }
+
+// namespace is blank, not "default" as testrunner evaulates the policyengine, but the "default" is added by kubeapiserver
+func Test_validate_image_latest_ifnotpresent_deny(t *testing.T) {
+	testScenario(t, "/test/scenarios/test/scenario_validate_image_latest_ifnotpresent_deny.yaml")
+
+}
+
+func Test_validate_image_latest_ifnotpresent_pass(t *testing.T) {
+	testScenario(t, "test/scenarios/test/scenario_validate_image_latest_ifnotpresent_pass.yaml")
+}
+
+func Test_validate_image_tag_notspecified_deny(t *testing.T) {
+	testScenario(t, "test/scenarios/test/scenario_validate_image_tag_notspecified_deny.yaml")
+}
+
+func Test_validate_image_tag_notspecified_pass(t *testing.T) {
+	testScenario(t, "test/scenarios/test/scenario_validate_image_tag_notspecified_pass.yaml")
+}
+
+func Test_validate_image_pullpolicy_notalways_deny(t *testing.T) {
+	testScenario(t, "test/scenarios/test/scenario_validate_image_pullpolicy_notalways_deny.yaml")
+}
+
+func Test_validate_image_pullpolicy_notalways_pass(t *testing.T) {
+	testScenario(t, "test/scenarios/test/scenario_validate_image_pullpolicy_notalways_pass.yaml")
+}
+
+func Test_validate_image_tag_latest_deny(t *testing.T) {
+	testScenario(t, "test/scenarios/test/scenario_validate_image_tag_latest_deny.yaml")
+}
+
+func Test_validate_image_tag_latest_pass(t *testing.T) {
+	testScenario(t, "test/scenarios/test/scenario_validate_image_tag_latest_pass.yaml")
+}
+
+func Test_mutate_pod_disable_automoutingapicred_pass(t *testing.T) {
+	testScenario(t, "test/scenarios/test/scenario_mutate_pod_disable_automountingapicred.yaml")
+}

--- a/pkg/webhooks/policymutation.go
+++ b/pkg/webhooks/policymutation.go
@@ -60,9 +60,9 @@ func generateJSONPatchesForDefaults(policy *kyverno.ClusterPolicy) ([]byte, []st
 }
 
 func defaultvalidationFailureAction(policy *kyverno.ClusterPolicy) ([]byte, string) {
-	// default ValidationFailureAction to "enforce" if not specified
+	// default ValidationFailureAction to "audit" if not specified
 	if policy.Spec.ValidationFailureAction == "" {
-		glog.V(4).Infof("defaulting policy %s 'ValidationFailureAction' to '%s'", policy.Name, BlockChanges)
+		glog.V(4).Infof("defaulting policy %s 'ValidationFailureAction' to '%s'", policy.Name, Audit)
 		jsonPatch := struct {
 			Path  string `json:"path"`
 			Op    string `json:"op"`
@@ -70,15 +70,15 @@ func defaultvalidationFailureAction(policy *kyverno.ClusterPolicy) ([]byte, stri
 		}{
 			"/spec/validationFailureAction",
 			"add",
-			BlockChanges, //enforce
+			Audit, //audit
 		}
 		patchByte, err := json.Marshal(jsonPatch)
 		if err != nil {
-			glog.Errorf("failed to set default 'ValidationFailureAction' to '%s' for policy %s", BlockChanges, policy.Name)
+			glog.Errorf("failed to set default 'ValidationFailureAction' to '%s' for policy %s", Audit, policy.Name)
 			return nil, ""
 		}
-		glog.V(4).Infof("generate JSON Patch to set default 'ValidationFailureAction' to '%s' for policy %s", BlockChanges, policy.Name)
-		return patchByte, fmt.Sprintf("default 'ValidationFailureAction' to '%s'", BlockChanges)
+		glog.V(4).Infof("generate JSON Patch to set default 'ValidationFailureAction' to '%s' for policy %s", Audit, policy.Name)
+		return patchByte, fmt.Sprintf("default 'ValidationFailureAction' to '%s'", Audit)
 	}
 	return nil, ""
 }

--- a/pkg/webhooks/utils.go
+++ b/pkg/webhooks/utils.go
@@ -18,16 +18,16 @@ func isResponseSuccesful(engineReponses []engine.EngineResponseNew) bool {
 	return true
 }
 
-// returns true -> if there is even one policy that blocks resource requst
+// returns true -> if there is even one policy that blocks resource request
 // returns false -> if all the policies are meant to report only, we dont block resource request
 func toBlockResource(engineReponses []engine.EngineResponseNew) bool {
 	for _, er := range engineReponses {
-		if er.PolicyResponse.ValidationFailureAction != ReportViolation {
-			glog.V(4).Infof("ValidationFailureAction set to enforce for policy %s , blocking resource ceation", er.PolicyResponse.Policy)
+		if er.PolicyResponse.ValidationFailureAction == Enforce {
+			glog.V(4).Infof("ValidationFailureAction set to enforce for policy %s , blocking resource request ", er.PolicyResponse.Policy)
 			return true
 		}
 	}
-	glog.V(4).Infoln("ValidationFailureAction set to audit, allowing resource creation, reporting with violation")
+	glog.V(4).Infoln("ValidationFailureAction set to audit, allowing resource request, reporting with policy violation")
 	return false
 }
 
@@ -78,8 +78,8 @@ func getApplicableKindsForPolicy(p *kyverno.ClusterPolicy) []string {
 
 // Policy Reporting Modes
 const (
-	BlockChanges    = "enforce"
-	ReportViolation = "audit"
+	Enforce = "enforce" // blocks the request on failure
+	Audit   = "audit"   // dont block the request on failure, but report failiures as policy violations
 )
 
 func processResourceWithPatches(patch []byte, resource []byte) []byte {

--- a/test/output/output_mutate_pod_disable_automoutingapicred.yaml
+++ b/test/output/output_mutate_pod_disable_automoutingapicred.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: 
+  labels:
+    app: myapp
+  name: myapp-pod
+spec:
+  automountServiceAccountToken: false
+  containers:
+  - image: nginx
+    imagePullPolicy: IfNotPresent
+    name: nginx
+    resources: {}
+  serviceAccountName: default
+status: {}

--- a/test/scenarios/test/scenario_mutate_pod_disable_automountingapicred.yaml
+++ b/test/scenarios/test/scenario_mutate_pod_disable_automountingapicred.yaml
@@ -1,0 +1,19 @@
+# file path relative to project root
+input:
+  policy: examples/best_practices/policy_mutate_pod_disable_automountingapicred.yaml
+  resource: examples/best_practices/resource_mutate_pod_disable_automountingapicred.yaml
+expected:
+  mutation:
+    patchedresource: test/output/output_mutate_pod_disable_automoutingapicred.yaml
+    policyresponse:
+      policy: mutate-pod-disable-automoutingapicred
+      resource:
+        kind: Pod
+        apiVersion: v1
+        namespace: ''
+        name: myapp-pod
+      rules:
+        - name: pod-disable-automoutingapicred
+          type: Mutation
+          message: "succesfully process overlay"
+          success: true

--- a/test/scenarios/test/scenario_validate_image_latest_ifnotpresent_deny.yaml
+++ b/test/scenarios/test/scenario_validate_image_latest_ifnotpresent_deny.yaml
@@ -1,0 +1,18 @@
+# file path relative to project root
+input:
+  policy: examples/best_practices/policy_validate_image_latest_ifnotpresent_deny.yaml
+  resource: examples/best_practices/resource_validate_image_latest_ifnotpresent_deny.yaml
+expected:
+  validation:
+    policyresponse:
+      policy: validate-image
+      resource:
+        kind: Pod
+        apiVersion: v1
+        namespace: ''
+        name: myapp-pod
+      rules:
+        - name: validate-tag
+          type: Validation
+          message: "Validation rule 'validate-tag' failed at '/spec/containers/0/imagePullPolicy/' for resource Pod//myapp-pod. imagePullPolicy 'IfNotPresent' forbidden with image tag 'latest'"
+          success: false    

--- a/test/scenarios/test/scenario_validate_image_latest_ifnotpresent_pass.yaml
+++ b/test/scenarios/test/scenario_validate_image_latest_ifnotpresent_pass.yaml
@@ -1,0 +1,18 @@
+# file path relative to project root
+input:
+  policy: examples/best_practices/policy_validate_image_latest_ifnotpresent_deny.yaml
+  resource: examples/best_practices/resource_validate_image_latest_ifnotpresent_pass.yaml
+expected:
+  validation:
+    policyresponse:
+      policy: validate-image
+      resource:
+        kind: Pod
+        apiVersion: v1
+        namespace: ''
+        name: myapp-pod
+      rules:
+        - name: validate-tag
+          type: Validation
+          message: "Validation rule 'validate-tag' succesfully validated"
+          success: true    

--- a/test/scenarios/test/scenario_validate_image_pullpolicy_notalways_deny.yaml
+++ b/test/scenarios/test/scenario_validate_image_pullpolicy_notalways_deny.yaml
@@ -1,0 +1,18 @@
+# file path relative to project root
+input:
+  policy: examples/best_practices/policy_validate_image_pullpolicy_notalways_deny.yaml
+  resource: examples/best_practices/resource_validate_image_pullpolicy_notalways_deny.yaml
+expected:
+  validation:
+    policyresponse:
+      policy: validate-image-pullpolicy-notalways
+      resource:
+        kind: Pod
+        apiVersion: v1
+        namespace: ''
+        name: myapp-pod
+      rules:
+        - name: image-pullpolicy-notalways
+          type: Validation
+          message: "Validation rule 'image-pullpolicy-notalways' failed at '/spec/containers/0/imagePullPolicy/' for resource Pod//myapp-pod. image pull policy 'Always' forbidden"
+          success: false    

--- a/test/scenarios/test/scenario_validate_image_pullpolicy_notalways_pass.yaml
+++ b/test/scenarios/test/scenario_validate_image_pullpolicy_notalways_pass.yaml
@@ -1,0 +1,18 @@
+# file path relative to project root
+input:
+  policy: examples/best_practices/policy_validate_image_pullpolicy_notalways_deny.yaml
+  resource: examples/best_practices/resource_validate_image_pullpolicy_notalways_pass.yaml
+expected:
+  validation:
+    policyresponse:
+      policy: validate-image-pullpolicy-notalways
+      resource:
+        kind: Pod
+        apiVersion: v1
+        namespace: ''
+        name: myapp-pod
+      rules:
+        - name: image-pullpolicy-notalways
+          type: Validation
+          message: "Validation rule 'image-pullpolicy-notalways' succesfully validated"
+          success: true    

--- a/test/scenarios/test/scenario_validate_image_tag_latest_deny.yaml
+++ b/test/scenarios/test/scenario_validate_image_tag_latest_deny.yaml
@@ -1,0 +1,18 @@
+# file path relative to project root
+input:
+  policy: examples/best_practices/policy_validate_image_tag_latest_deny.yaml
+  resource: examples/best_practices/resource_validate_image_tag_latest_deny.yaml
+expected:
+  validation:
+    policyresponse:
+      policy: validate-image-tag-notlatest
+      resource:
+        kind: Pod
+        apiVersion: v1
+        namespace: ''
+        name: myapp-pod
+      rules:
+        - name: image-tag-notlatest
+          type: Validation
+          message: "Validation rule 'image-tag-notlatest' failed at '/spec/containers/0/image/' for resource Pod//myapp-pod. image tag 'latest' forbidden"
+          success: false

--- a/test/scenarios/test/scenario_validate_image_tag_latest_pass.yaml
+++ b/test/scenarios/test/scenario_validate_image_tag_latest_pass.yaml
@@ -1,0 +1,18 @@
+# file path relative to project root
+input:
+  policy: examples/best_practices/policy_validate_image_tag_latest_deny.yaml
+  resource: examples/best_practices/resource_validate_image_tag_latest_pass.yaml
+expected:
+  validation:
+    policyresponse:
+      policy: validate-image-tag-notlatest
+      resource:
+        kind: Pod
+        apiVersion: v1
+        namespace: ''
+        name: myapp-pod
+      rules:
+        - name: image-tag-notlatest
+          type: Validation
+          message: "Validation rule 'image-tag-notlatest' succesfully validated"
+          success: true

--- a/test/scenarios/test/scenario_validate_image_tag_notspecified_deny.yaml
+++ b/test/scenarios/test/scenario_validate_image_tag_notspecified_deny.yaml
@@ -1,0 +1,18 @@
+# file path relative to project root
+input:
+  policy: examples/best_practices/policy_validate_image_tag_notspecified_deny.yaml
+  resource: examples/best_practices/resource_validate_image_tag_notspecified_deny.yaml
+expected:
+  validation:
+    policyresponse:
+      policy: validate-image-tag-notspecified
+      resource:
+        kind: Pod
+        apiVersion: v1
+        namespace: ''
+        name: myapp-pod
+      rules:
+        - name: image-tag-notspecified
+          type: Validation
+          message: "Validation rule 'image-tag-notspecified' failed at '/spec/containers/0/image/' for resource Pod//myapp-pod. image tag not specified"
+          success: false    

--- a/test/scenarios/test/scenario_validate_image_tag_notspecified_pass.yaml
+++ b/test/scenarios/test/scenario_validate_image_tag_notspecified_pass.yaml
@@ -1,0 +1,18 @@
+# file path relative to project root
+input:
+  policy: examples/best_practices/policy_validate_image_tag_notspecified_deny.yaml
+  resource: examples/best_practices/resource_validate_image_tag_notspecified_pass.yaml
+expected:
+  validation:
+    policyresponse:
+      policy: validate-image-tag-notspecified
+      resource:
+        kind: Pod
+        apiVersion: v1
+        namespace: ''
+        name: myapp-pod
+      rules:
+        - name: image-tag-notspecified
+          type: Validation
+          message: "Validation rule 'image-tag-notspecified' succesfully validated"
+          success: true    


### PR DESCRIPTION
Set the default failure action to 'audit', if not specified in the policy.
The policy mutating webhook defaults the value.

fixes #342 