### PR TITLE
delete PV if the P it refers to is stale

### DIFF
--- a/pkg/policy/controller.go
+++ b/pkg/policy/controller.go
@@ -202,7 +202,7 @@ func (pc *PolicyController) addPolicyViolation(obj interface{}) {
 		// there is no cluster policy for this violation, so we can delete this cluster policy violation
 		glog.V(4).Infof("PolicyViolation %s does not belong to an active policy, will be cleanedup", pv.Name)
 		if err := pc.pvControl.DeletePolicyViolation(pv.Name); err != nil {
-			glog.Error("Failed to deleted policy violation %s: %v", pv.Name, err)
+			glog.Errorf("Failed to deleted policy violation %s: %v", pv.Name, err)
 			return
 		}
 		glog.V(4).Infof("PolicyViolation %s deleted", pv.Name)
@@ -257,7 +257,7 @@ func (pc *PolicyController) updatePolicyViolation(old, cur interface{}) {
 			// there is no cluster policy for this violation, so we can delete this cluster policy violation
 			glog.V(4).Infof("PolicyViolation %s does not belong to an active policy, will be cleanedup", curPV.Name)
 			if err := pc.pvControl.DeletePolicyViolation(curPV.Name); err != nil {
-				glog.Error("Failed to deleted policy violation %s: %v", curPV.Name, err)
+				glog.Errorf("Failed to deleted policy violation %s: %v", curPV.Name, err)
 				return
 			}
 			glog.V(4).Infof("PolicyViolation %s deleted", curPV.Name)


### PR DESCRIPTION
Resolves Issues #388 
Testing:
- Create a policy violation object with no active policy, then the policy violation is removed as the policy it refers to is inactive.
