### PR TITLE
fix generate format

### DIFF
--- a/samples/RequireNSLimitsQuotas.md
+++ b/samples/RequireNSLimitsQuotas.md
@@ -1,6 +1,6 @@
 # Configure namespace limits and quotas
 
-To limit the number of resources like CPU and memory, as well as objects that may be consumed by workloads in a namespace, it is important to configure resource limits and quotas for each namespace.
+To limit the number of resources like CPU and memory, as well as objects that may be consumed by workloads in a namespace, it is important to configure resource limits and quotas for each namespace. 
 
 ## Additional Information
 
@@ -14,10 +14,10 @@ To limit the number of resources like CPU and memory, as well as objects that ma
 apiVersion: kyverno.io/v1alpha1
 kind: ClusterPolicy
 metadata:
-  name: validate-namespace-quota
+  name: generate-namespace-quota
 spec:
   rules:
-  - name: validate-namespace-quota
+  - name: generate-namespace-quota
     match:
       resources:
         kinds:
@@ -25,11 +25,11 @@ spec:
     generate:
       kind: ResourceQuota
       name: "defaultresourcequota"
-      spec:
-        hard:
-          requests.cpu: "*"
-          requests.memory: "*"
-          limits.cpu: "*"
-          limits.memory: "*"
+      data:
+        spec:
+          hard:
+            requests.cpu: '4'
+            requests.memory: '16Gi'
+            limits.cpu: '4'
+            limits.memory: '16Gi'
 ````
-

--- a/samples/best_practices/require_namespace_quota.yaml
+++ b/samples/best_practices/require_namespace_quota.yaml
@@ -1,7 +1,7 @@
 apiVersion: kyverno.io/v1alpha1
 kind: ClusterPolicy
 metadata:
-  name: validate-namespace-quota
+  name: generate-namespace-quota
   annotations:
     policies.kyverno.io/category: Resource Quota
     policies.kyverno.io/description: To limit the number of objects, as well as the 
@@ -9,7 +9,7 @@ metadata:
       to create resource limits and quotas for each namespace.
 spec:
   rules:
-  - name: validate-namespace-quota
+  - name: generate-namespace-quota
     match:
       resources:
         kinds:
@@ -20,7 +20,7 @@ spec:
       data:
         spec:
           hard:
-            requests.cpu: '1'
-            requests.memory: "1Gi"
-            limits.cpu: '3'
-            limits.memory: "2Gi"
+            requests.cpu: '4'
+            requests.memory: "16Gi"
+            limits.cpu: '4'
+            limits.memory: "16Gi"

--- a/samples/best_practices/require_namespace_quota.yaml
+++ b/samples/best_practices/require_namespace_quota.yaml
@@ -17,9 +17,10 @@ spec:
     generate:
       kind: ResourceQuota
       name: "defaultresourcequota"
-      spec:
-        hard:
-          requests.cpu: "*"
-          requests.memory: "*"
-          limits.cpu: "*"
-          limits.memory: "*"
+      data:
+        spec:
+          hard:
+            requests.cpu: '1'
+            requests.memory: "1Gi"
+            limits.cpu: '3'
+            limits.memory: "2Gi"

--- a/test/scenarios/samples/best_practices/scenario_validate_require_namespace_quota.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_require_namespace_quota.yaml
@@ -9,14 +9,14 @@ expected:
         kind: ResourceQuota
         namespace: test-namespace-quota
     policyresponse:
-      policy: validate-namespace-quota
+      policy: generate-namespace-quota
       resource:
         kind: Namespace
         apiVersion: v1
         namespace: ''
         name: test-namespace-quota
       rules:
-        - name: validate-namespace-quota
+        - name: generate-namespace-quota
           type: Generation
           success: true
           message: created resource ResourceQuota/test-namespace-quota/defaultresourcequota


### PR DESCRIPTION
Changes:
- `data` was not specified in generate policy
- when specifying values for cpu we need to user `requests.cpu: '1'`, then the value is considered as float64(type is preserved). But if we use value as `1` & `"1"`, its type is string. As the type interpreted in string in go, the case for float needs to be handled explicitly as described in issue https://github.com/nirmata/kyverno/issues/375.

The correction uses `''` to preserve the types and add values for requests and limits.

In this policy, if the namespace already contains a resource quota(existing resources) with name `defaultresourcequota` and has the configuration as
```
        spec:
          hard:
            requests.cpu: '1'
            requests.memory: "1Gi"
            limits.cpu: '3'
            limits.memory: "2Gi"
```
then the policy is successful. But if the resourcequota is not present or the above configuration is not present, then a violation would be created.

fixes #398 