### PR TITLE
add backward support for command line arguments for filtering resources

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,9 @@ var (
 	cpu            bool
 	memory         bool
 	webhookTimeout int
+	//TODO: this has been added to backward support command line arguments
+	// will be removed in future and the configuration will be set only via configmaps
+	filterK8Resources string
 )
 
 // TODO: tune resync time differently for each informer
@@ -95,7 +98,7 @@ func main() {
 	// dyamically load the configuration from configMap
 	// - resource filters
 	// if the configMap is update, the configuration will be updated :D
-	configData := config.NewConfigData(kubeClient, kubeInformer.Core().V1().ConfigMaps())
+	configData := config.NewConfigData(kubeClient, kubeInformer.Core().V1().ConfigMaps(), filterK8Resources)
 
 	// EVENT GENERATOR
 	// - generate event with retry mechanism
@@ -178,7 +181,9 @@ func init() {
 	// by default is to profile cpu
 	flag.BoolVar(&cpu, "cpu", false, "cpu profilling feature gate, default to false || cpu and memory profiling cannot be enabled at the same time")
 	flag.BoolVar(&memory, "memory", false, "memory profilling feature gate, default to false || cpu and memory profiling cannot be enabled at the same time")
-
+	//TODO: this has been added to backward support command line arguments
+	// will be removed in future and the configuration will be set only via configmaps
+	flag.StringVar(&filterK8Resources, "filterK8Resources", "", "k8 resource in format [kind,namespace,name] where policy is not evaluated by the admission webhook. example --filterKind \"[Deployment, kyverno, kyverno]\" --filterKind \"[Deployment, kyverno, kyverno],[Events, *, *]\"")
 	flag.IntVar(&webhookTimeout, "webhooktimeout", 2, "timeout for webhook configurations")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")


### PR DESCRIPTION
Dynamic configuration:
- Refer to configMap to get the resources to be filtered, we will watch the configMap for changes and accordingly update.
- To support backward compatibility, the user can also provide resources to be filtered as command-line arguments. These will be used as initial list of resources to be filtered. 
- If both command line and config map resources are defined, we initialize using command line arguments, but the configMap resync will overwrite the list of resources to be filtered. So the configMap will be considered.

Add comments for removal of command-line argument option.