### PR TITLE
update message string

### DIFF
--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -87,7 +87,7 @@ func validatePatterns(resource unstructured.Unstructured, rule kyverno.Rule) (re
 			// rule application failed
 			glog.V(4).Infof("Validation rule '%s' failed at '%s' for resource %s/%s/%s. %s: %v", rule.Name, path, resource.GetKind(), resource.GetNamespace(), resource.GetName(), rule.Validation.Message, err)
 			response.Success = false
-			response.Message = fmt.Sprintf("Validation rule '%s' failed at '%s' for resource %s/%s/%s. %s", rule.Name, path, resource.GetKind(), resource.GetNamespace(), resource.GetName(), rule.Validation.Message)
+			response.Message = fmt.Sprintf("Validation rule '%s' failed at '%s' for resource %s/%s/%s. %s.", rule.Name, path, resource.GetKind(), resource.GetNamespace(), resource.GetName(), rule.Validation.Message)
 			return response
 		}
 		// rule application succesful
@@ -122,7 +122,7 @@ func validatePatterns(resource unstructured.Unstructured, rule kyverno.Rule) (re
 			response.Success = false
 			response.Success = false
 			var errorStr []string
-			errorStr = append(errorStr, fmt.Sprintf("Validation rule '%s' failed to validate patterns defined in anyPattern. %s", rule.Name, rule.Validation.Message))
+			errorStr = append(errorStr, fmt.Sprintf("Validation rule '%s' failed to validate patterns defined in anyPattern. %s.", rule.Name, rule.Validation.Message))
 			for index, err := range errs {
 				glog.V(4).Infof("anyPattern[%d] failed at path %s: %v", index, failedPaths[index], err)
 				str := fmt.Sprintf("anyPattern[%d] failed at path %s", index, failedPaths[index])

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -1818,7 +1818,7 @@ func TestValidate_image_tag_fail(t *testing.T) {
 	assert.NilError(t, err)
 	msgs := []string{
 		"Validation rule 'validate-tag' succesfully validated",
-		"Validation rule 'validate-latest' failed at '/spec/containers/0/imagePullPolicy/' for resource Pod//myapp-pod. imagePullPolicy 'Always' required with tag 'latest'",
+		"Validation rule 'validate-latest' failed at '/spec/containers/0/imagePullPolicy/' for resource Pod//myapp-pod. imagePullPolicy 'Always' required with tag 'latest'.",
 	}
 	er := Validate(policy, *resourceUnstructured)
 	for index, r := range er.PolicyResponse.Rules {
@@ -1992,7 +1992,7 @@ func TestValidate_Fail_anyPattern(t *testing.T) {
 	resourceUnstructured, err := ConvertToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(policy, *resourceUnstructured)
-	msgs := []string{"Validation rule 'check-default-namespace' failed to validate patterns defined in anyPattern. A namespace is required; anyPattern[0] failed at path /metadata/namespace/; anyPattern[1] failed at path /metadata/namespace/"}
+	msgs := []string{"Validation rule 'check-default-namespace' failed to validate patterns defined in anyPattern. A namespace is required.; anyPattern[0] failed at path /metadata/namespace/; anyPattern[1] failed at path /metadata/namespace/"}
 	for index, r := range er.PolicyResponse.Rules {
 		assert.Equal(t, r.Message, msgs[index])
 	}
@@ -2073,7 +2073,7 @@ func TestValidate_host_network_port(t *testing.T) {
 	resourceUnstructured, err := ConvertToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(policy, *resourceUnstructured)
-	msgs := []string{"Validation rule 'validate-host-network-port' failed at '/spec/containers/0/ports/0/hostPort/' for resource Pod//nginx-host-network. Host network and port are not allowed"}
+	msgs := []string{"Validation rule 'validate-host-network-port' failed at '/spec/containers/0/ports/0/hostPort/' for resource Pod//nginx-host-network. Host network and port are not allowed."}
 
 	for index, r := range er.PolicyResponse.Rules {
 		assert.Equal(t, r.Message, msgs[index])
@@ -2250,7 +2250,7 @@ func TestValidate_anchor_arraymap_fail(t *testing.T) {
 	resourceUnstructured, err := ConvertToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(policy, *resourceUnstructured)
-	msgs := []string{"Validation rule 'validate-host-path' failed at '/spec/volumes/0/hostPath/path/' for resource Pod//image-with-hostpath. Host path '/var/lib/' is not allowed"}
+	msgs := []string{"Validation rule 'validate-host-path' failed at '/spec/volumes/0/hostPath/path/' for resource Pod//image-with-hostpath. Host path '/var/lib/' is not allowed."}
 
 	for index, r := range er.PolicyResponse.Rules {
 		assert.Equal(t, r.Message, msgs[index])
@@ -2463,7 +2463,7 @@ func TestValidate_anchor_map_found_invalid(t *testing.T) {
 	resourceUnstructured, err := ConvertToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(policy, *resourceUnstructured)
-	msgs := []string{"Validation rule 'pod rule 2' failed at '/spec/securityContext/runAsNonRoot/' for resource Pod//myapp-pod. pod: validate run as non root user"}
+	msgs := []string{"Validation rule 'pod rule 2' failed at '/spec/securityContext/runAsNonRoot/' for resource Pod//myapp-pod. pod: validate run as non root user."}
 
 	for index, r := range er.PolicyResponse.Rules {
 		assert.Equal(t, r.Message, msgs[index])
@@ -2847,7 +2847,7 @@ func TestValidate_negationAnchor_deny(t *testing.T) {
 	resourceUnstructured, err := ConvertToUnstructured(rawResource)
 	assert.NilError(t, err)
 	er := Validate(policy, *resourceUnstructured)
-	msgs := []string{"Validation rule 'validate-host-path' failed at '/spec/volumes/0/hostPath/' for resource Pod//image-with-hostpath. Host path is not allowed"}
+	msgs := []string{"Validation rule 'validate-host-path' failed at '/spec/volumes/0/hostPath/' for resource Pod//image-with-hostpath. Host path is not allowed."}
 
 	for index, r := range er.PolicyResponse.Rules {
 		assert.Equal(t, r.Message, msgs[index])

--- a/samples/DisallowHostNetworkPort.md
+++ b/samples/DisallowHostNetworkPort.md
@@ -21,7 +21,7 @@ spec:
         kinds:
         - Pod
     validate:
-      message: "Defining hostNetwork and hostPort are not allowed."
+      message: "Defining hostNetwork and hostPort are not allowed"
       pattern:
         spec:
           (hostNetwork): false

--- a/samples/RunAsNonRootUser.md
+++ b/samples/RunAsNonRootUser.md
@@ -23,7 +23,7 @@ spec:
         kinds:
         - Pod
     validate:
-      message: "Root user is not allowed. Set runAsNonRoot to true."
+      message: "Root user is not allowed. Set runAsNonRoot to true"
       anyPattern:
       - spec:
           securityContext:

--- a/samples/best_practices/deny_runasrootuser.yaml
+++ b/samples/best_practices/deny_runasrootuser.yaml
@@ -16,7 +16,7 @@ spec:
         kinds:
         - Pod
     validate:
-      message: "Root user is not allowed. Set runAsNonRoot to true."
+      message: "Root user is not allowed. Set runAsNonRoot to true"
       anyPattern:
       - spec:
           securityContext:

--- a/samples/best_practices/disallow_host_network_hostport.yaml
+++ b/samples/best_practices/disallow_host_network_hostport.yaml
@@ -14,7 +14,7 @@ spec:
         kinds:
         - Pod
     validate:
-      message: "Defining hostNetwork and hostPort are not allowed."
+      message: "Defining hostNetwork and hostPort are not allowed"
       pattern:
         spec:
           (hostNetwork): false

--- a/test/policy/validate/policy_validate_disallow_default_serviceaccount.yaml
+++ b/test/policy/validate/policy_validate_disallow_default_serviceaccount.yaml
@@ -14,7 +14,7 @@ spec:
         kinds:
         - Pod
     validate:
-      message: "Prevent mounting of default service account."
+      message: "Prevent mounting of default service account"
       pattern:
         spec:
           serviceAccountName: "!default"

--- a/test/scenarios/other/scenario_validate_selinux_context.yaml
+++ b/test/scenarios/other/scenario_validate_selinux_context.yaml
@@ -15,5 +15,5 @@ expected:
       rules:
         - name: validate-selinux-options
           type: Validation
-          message: "Validation rule 'validate-selinux-options' failed at '/spec/containers/0/securityContext/seLinuxOptions/' for resource Pod/default/busybox-selinux. SELinux level is required"
+          message: "Validation rule 'validate-selinux-options' failed at '/spec/containers/0/securityContext/seLinuxOptions/' for resource Pod/default/busybox-selinux. SELinux level is required."
           success: false

--- a/test/scenarios/samples/best_practices/scenario_valiadate_require_image_tag_not_latest_deny.yaml
+++ b/test/scenarios/samples/best_practices/scenario_valiadate_require_image_tag_not_latest_deny.yaml
@@ -18,5 +18,5 @@ expected:
           success: true
         - name: image-tag-not-latest
           type: Validation
-          message: "Validation rule 'image-tag-not-latest' failed at '/spec/containers/0/image/' for resource Pod//myapp-pod. Using 'latest' image tag is restricted. Set image tag to a specific version"
+          message: "Validation rule 'image-tag-not-latest' failed at '/spec/containers/0/image/' for resource Pod//myapp-pod. Using 'latest' image tag is restricted. Set image tag to a specific version."
           success: false   

--- a/test/scenarios/samples/best_practices/scenario_validate_disallow_default_namespace.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_disallow_default_namespace.yaml
@@ -16,7 +16,7 @@ expected:
       rules:
         - name: check-default-namespace
           type: Validation
-          message: "Validation rule 'check-default-namespace' failed at '/metadata/namespace/' for resource Pod/default/myapp-pod. Using 'default' namespace is restricted"
+          message: "Validation rule 'check-default-namespace' failed at '/metadata/namespace/' for resource Pod/default/myapp-pod. Using 'default' namespace is restricted."
           success: false
         - name: check-namespace-exist
           type: Validation

--- a/test/scenarios/samples/best_practices/scenario_validate_disallow_host_filesystem.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_disallow_host_filesystem.yaml
@@ -14,5 +14,5 @@ expected:
       rules:
         - name: deny-use-of-host-fs
           type: Validation
-          message: Validation rule 'deny-use-of-host-fs' failed at '/spec/volumes/0/hostPath/' for resource Pod//image-with-hostpath. Host path is not allowed
+          message: Validation rule 'deny-use-of-host-fs' failed at '/spec/volumes/0/hostPath/' for resource Pod//image-with-hostpath. Host path is not allowed.
           success: false

--- a/test/scenarios/samples/best_practices/scenario_validate_disallow_hostpid_hostipc.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_disallow_hostpid_hostipc.yaml
@@ -14,5 +14,5 @@ expected:
       rules:
         - name: validate-hostpid-hostipc
           type: Validation
-          message: Validation rule 'validate-hostpid-hostipc' failed at '/spec/hostIPC/' for resource Pod//nginx-with-hostpid. Disallow use of host's pid namespace and host's ipc namespace
+          message: Validation rule 'validate-hostpid-hostipc' failed at '/spec/hostIPC/' for resource Pod//nginx-with-hostpid. Disallow use of host's pid namespace and host's ipc namespace.
           success: false   

--- a/test/scenarios/samples/best_practices/scenario_validate_disallow_new_capabilities.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_disallow_new_capabilities.yaml
@@ -14,5 +14,5 @@ expected:
       rules:
         - name: deny-new-capabilities
           type: Validation
-          message: Validation rule 'deny-new-capabilities' failed to validate patterns defined in anyPattern. Capabilities cannot be added; anyPattern[0] failed at path /spec/; anyPattern[1] failed at path /spec/containers/0/securityContext/capabilities/add/
+          message: Validation rule 'deny-new-capabilities' failed to validate patterns defined in anyPattern. Capabilities cannot be added.; anyPattern[0] failed at path /spec/; anyPattern[1] failed at path /spec/containers/0/securityContext/capabilities/add/
           success: false

--- a/test/scenarios/samples/best_practices/scenario_validate_disallow_node_port.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_disallow_node_port.yaml
@@ -13,5 +13,5 @@ expected:
       rules:
         - name: disallow-node-port
           type: Validation
-          message: Validation rule 'disallow-node-port' failed at '/spec/type/' for resource Service//my-service. Disallow service of type NodePort
+          message: Validation rule 'disallow-node-port' failed at '/spec/type/' for resource Service//my-service. Disallow service of type NodePort.
           success: false

--- a/test/scenarios/samples/best_practices/scenario_validate_disallow_priviledged_privelegesecalation.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_disallow_priviledged_privelegesecalation.yaml
@@ -14,6 +14,6 @@ expected:
       rules:
         - name: deny-privileged-priviligedescalation
           type: Validation
-          message: "Validation rule 'deny-privileged-priviligedescalation' failed to validate patterns defined in anyPattern. Privileged mode is not allowed. Set allowPrivilegeEscalation and privileged to false; anyPattern[0] failed at path /spec/securityContext/; anyPattern[1] failed at path /spec/containers/0/securityContext/allowPrivilegeEscalation/"
+          message: "Validation rule 'deny-privileged-priviligedescalation' failed to validate patterns defined in anyPattern. Privileged mode is not allowed. Set allowPrivilegeEscalation and privileged to false.; anyPattern[0] failed at path /spec/securityContext/; anyPattern[1] failed at path /spec/containers/0/securityContext/allowPrivilegeEscalation/"
           success: false
 

--- a/test/scenarios/samples/best_practices/scenario_validate_probes.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_probes.yaml
@@ -14,5 +14,5 @@ expected:
       rules:
         - name: check-probes
           type: Validation
-          message: Validation rule 'check-probes' failed at '/spec/containers/0/livenessProbe/' for resource Pod//myapp-pod. Liveness and readiness probes are required
+          message: Validation rule 'check-probes' failed at '/spec/containers/0/livenessProbe/' for resource Pod//myapp-pod. Liveness and readiness probes are required.
           success: false 

--- a/test/scenarios/samples/best_practices/scenario_validate_require_pod_requests_limits.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_require_pod_requests_limits.yaml
@@ -14,5 +14,5 @@ expected:
       rules:
         - name: check-resource-request-limit
           type: Validation
-          message: Validation rule 'check-resource-request-limit' failed at '/spec/containers/0/resources/limits/cpu/' for resource Pod//myapp-pod. CPU and memory resource requests and limits are required
+          message: Validation rule 'check-resource-request-limit' failed at '/spec/containers/0/resources/limits/cpu/' for resource Pod//myapp-pod. CPU and memory resource requests and limits are required.
           success: false 

--- a/test/scenarios/samples/best_practices/scenario_validate_require_readonly_rootfilesystem.yaml
+++ b/test/scenarios/samples/best_practices/scenario_validate_require_readonly_rootfilesystem.yaml
@@ -14,5 +14,5 @@ expected:
       rules:
         - name: validate-readonly-rootfilesystem
           type: Validation
-          message: Validation rule 'validate-readonly-rootfilesystem' failed at '/spec/containers/0/securityContext/readOnlyRootFilesystem/' for resource Pod//ghost-with-readonly-rootfilesystem. Container require read-only rootfilesystem
+          message: Validation rule 'validate-readonly-rootfilesystem' failed at '/spec/containers/0/securityContext/readOnlyRootFilesystem/' for resource Pod//ghost-with-readonly-rootfilesystem. Container require read-only rootfilesystem.
           success: false   

--- a/test/scenarios/samples/more/scenario_validate_container_capabilities.yaml
+++ b/test/scenarios/samples/more/scenario_validate_container_capabilities.yaml
@@ -15,5 +15,5 @@ expected:
       rules:
         - name: validate-container-capablities
           type: Validation
-          message: "Validation rule 'validate-container-capablities' failed at '/spec/containers/0/securityContext/capabilities/add/0/' for resource Pod//add-capabilities. Allow certain linux capability"
+          message: "Validation rule 'validate-container-capablities' failed at '/spec/containers/0/securityContext/capabilities/add/0/' for resource Pod//add-capabilities. Allow certain linux capability."
           success: false

--- a/test/scenarios/samples/more/scenario_validate_sysctl_configs.yaml
+++ b/test/scenarios/samples/more/scenario_validate_sysctl_configs.yaml
@@ -15,5 +15,5 @@ expected:
       rules:
         - name: allow-portrange-with-sysctl
           type: Validation
-          message: "Validation rule 'allow-portrange-with-sysctl' failed at '/spec/securityContext/sysctls/0/value/' for resource Pod//nginx. Allowed port range is from 1024 to 65535"
+          message: "Validation rule 'allow-portrange-with-sysctl' failed at '/spec/securityContext/sysctls/0/value/' for resource Pod//nginx. Allowed port range is from 1024 to 65535."
           success: false


### PR DESCRIPTION
fixes #431 

- Add a period at the end of `Validation.Message`.
- Update scenario files expected responses.
- Update policy `Validation.Message` to not use a period( for consistency).
- Update the markdown files for the policies that have been updated.