### PR TITLE
458 cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,8 +154,8 @@ func main() {
 	// Start the components
 	pInformer.Start(stopCh)
 	kubeInformer.Start(stopCh)
-	if err := configData.Run(kubeInformer.Core().V1().ConfigMaps(), stopCh); err != nil {
-		glog.Fatalf("Unable loading dynamic configuration: %v\n", err)
+	if err := configData.Run(stopCh); err != nil {
+		glog.Fatalf("Unable to load dynamic configuration: %v\n", err)
 	}
 	go pc.Run(1, stopCh)
 	go pvc.Run(1, stopCh)

--- a/pkg/api/kyverno/v1alpha1/utils.go
+++ b/pkg/api/kyverno/v1alpha1/utils.go
@@ -62,3 +62,13 @@ func (rs ResourceSpec) ToKey() string {
 	}
 	return rs.Kind + "." + rs.Namespace + "." + rs.Name
 }
+
+//BuildKey builds the key
+func BuildResourceKey(kind, namespace, name string) string {
+	resource := ResourceSpec{
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      name,
+	}
+	return resource.ToKey()
+}

--- a/pkg/policy/cleanup.go
+++ b/pkg/policy/cleanup.go
@@ -107,6 +107,7 @@ func getPVOnResource(pvLister kyvernolister.ClusterPolicyViolationLister, policy
 		glog.V(4).Infof("policy violation does not exist with labels %v", labelMap)
 		return kyverno.ClusterPolicyViolation{}, nil
 	}
+	glog.V(4).Infof("shiv: got resource: %v", *pvs[0])
 	// return a copy of pv
 	return *pvs[0], nil
 }

--- a/pkg/policy/cleanup.go
+++ b/pkg/policy/cleanup.go
@@ -1,0 +1,129 @@
+package policy
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/golang/glog"
+	kyverno "github.com/nirmata/kyverno/pkg/api/kyverno/v1alpha1"
+	kyvernolister "github.com/nirmata/kyverno/pkg/client/listers/kyverno/v1alpha1"
+	dclient "github.com/nirmata/kyverno/pkg/dclient"
+	"github.com/nirmata/kyverno/pkg/engine"
+	"github.com/nirmata/kyverno/pkg/policyviolation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func (pc *PolicyController) cleanUpPolicyViolation(pResponse engine.PolicyResponse) {
+	// 1- check if there is violation on resource (label:Selector)
+	// 2- check if there is violation on owner
+	//    - recursively get owner by queries the api server for owner information of the resource
+
+	// there can be multiple violations as a resource can have multiple owners
+	pvs, err := getPv(pc.pvLister, pc.client, pResponse.Policy, pResponse.Resource.Kind, pResponse.Resource.Namespace, pResponse.Resource.Name)
+	if err != nil {
+		glog.Errorf("failed to cleanUp violations: %v", err)
+	}
+	for _, pv := range pvs {
+		if reflect.DeepEqual(pv, kyverno.ClusterPolicyViolation{}) {
+			continue
+		}
+		glog.V(4).Infof("cleanup violations %s, on %s/%s/%s", pv.Name, pv.Spec.Kind, pv.Spec.Namespace, pv.Spec.Name)
+		if err := pc.pvControl.DeletePolicyViolation(pv.Name); err != nil {
+			glog.Errorf("failed to delete policy violation: %v", err)
+			continue
+		}
+		// create event for policy violation cleanup
+		pvCleanUpEvent(pc.eventGen, pv)
+	}
+}
+
+func getPv(pvLister kyvernolister.ClusterPolicyViolationLister, client *dclient.Client, policyName, kind, namespace, name string) ([]kyverno.ClusterPolicyViolation, error) {
+	var pvs []kyverno.ClusterPolicyViolation
+	var err error
+	// Check Violation on resource
+	pv, err := getPVOnResource(pvLister, policyName, kind, namespace, name)
+	if err != nil {
+		glog.V(4).Infof("error while fetching pv: %v", err)
+		return []kyverno.ClusterPolicyViolation{}, err
+	}
+	if !reflect.DeepEqual(pv, kyverno.ClusterPolicyViolation{}) {
+		// found a pv on resource
+		pvs = append(pvs, pv)
+		return pvs, nil
+	}
+	// Check Violations on owner
+	pvs, err = getPVonOwnerRef(pvLister, client, policyName, kind, namespace, name)
+	if err != nil {
+		glog.V(4).Infof("error while fetching pv: %v", err)
+		return []kyverno.ClusterPolicyViolation{}, err
+	}
+	return pvs, nil
+}
+
+func getPVonOwnerRef(pvLister kyvernolister.ClusterPolicyViolationLister, dclient *dclient.Client, policyName, kind, namespace, name string) ([]kyverno.ClusterPolicyViolation, error) {
+	var pvs []kyverno.ClusterPolicyViolation
+	// get resource
+	resource, err := dclient.GetResource(kind, namespace, name)
+	if err != nil {
+		glog.V(4).Info("error while fetching the resource: %v", err)
+		return pvs, err
+	}
+	// get owners
+	// getOwners returns nil if there is any error
+	owners := policyviolation.GetOwners(dclient, *resource)
+	// as we can have multiple top level owners to a resource
+	// check if pv exists on each one
+	// does not check for cycles
+	for _, owner := range owners {
+		pv, err := getPVOnResource(pvLister, policyName, owner.Kind, owner.Namespace, owner.Name)
+		if err != nil {
+			glog.Errorf("error while fetching resource owners: %v", err)
+			continue
+		}
+		pvs = append(pvs, pv)
+	}
+	return pvs, nil
+}
+
+// Wont do the claiming of objects, just lookup based on selectors and owner references
+func getPVOnResource(pvLister kyvernolister.ClusterPolicyViolationLister, policyName, kind, namespace, name string) (kyverno.ClusterPolicyViolation, error) {
+	resourceKey := kyverno.BuildResourceKey(kind, namespace, name)
+	labelMap := map[string]string{"policy": policyName, "resource": resourceKey}
+	pvSelector, err := converLabelToSelector(labelMap)
+	if err != nil {
+		glog.Errorf("failed to generate label sector for policy %s and resourcr %s", policyName, resourceKey)
+		return kyverno.ClusterPolicyViolation{}, fmt.Errorf("failed to generate label sector for policy %s and resourcr %s", policyName, resourceKey)
+	}
+
+	pvs, err := pvLister.List(pvSelector)
+	if err != nil {
+		glog.Errorf("unable to list policy violations with label selector %v: %v", pvSelector, err)
+		return kyverno.ClusterPolicyViolation{}, err
+	}
+	if len(pvs) > 1 {
+		glog.Errorf("more than one policy violation exists  with labels %v", labelMap)
+		return kyverno.ClusterPolicyViolation{}, fmt.Errorf("more than one policy violation exists  with labels %v", labelMap)
+	}
+	if len(pvs) == 0 {
+		glog.V(4).Infof("policy violation does not exist with labels %v", labelMap)
+		return kyverno.ClusterPolicyViolation{}, nil
+	}
+	// return a copy of pv
+	return *pvs[0], nil
+}
+
+func converLabelToSelector(labelMap map[string]string) (labels.Selector, error) {
+	ls := &metav1.LabelSelector{}
+	err := metav1.Convert_Map_string_To_string_To_v1_LabelSelector(&labelMap, ls, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	policyViolationSelector, err := metav1.LabelSelectorAsSelector(ls)
+	if err != nil {
+		return nil, fmt.Errorf("invalid label selector: %v", err)
+	}
+
+	return policyViolationSelector, nil
+}

--- a/pkg/policy/cleanup.go
+++ b/pkg/policy/cleanup.go
@@ -64,7 +64,7 @@ func getPVonOwnerRef(pvLister kyvernolister.ClusterPolicyViolationLister, dclien
 	// get resource
 	resource, err := dclient.GetResource(kind, namespace, name)
 	if err != nil {
-		glog.V(4).Info("error while fetching the resource: %v", err)
+		glog.V(4).Infof("error while fetching the resource: %v", err)
 		return pvs, err
 	}
 	// get owners

--- a/pkg/policy/cleanup.go
+++ b/pkg/policy/cleanup.go
@@ -33,8 +33,6 @@ func (pc *PolicyController) cleanUpPolicyViolation(pResponse engine.PolicyRespon
 			glog.Errorf("failed to delete policy violation: %v", err)
 			continue
 		}
-		// create event for policy violation cleanup
-		pvCleanUpEvent(pc.eventGen, pv)
 	}
 }
 

--- a/pkg/policy/cleanup.go
+++ b/pkg/policy/cleanup.go
@@ -107,7 +107,6 @@ func getPVOnResource(pvLister kyvernolister.ClusterPolicyViolationLister, policy
 		glog.V(4).Infof("policy violation does not exist with labels %v", labelMap)
 		return kyverno.ClusterPolicyViolation{}, nil
 	}
-	glog.V(4).Infof("shiv: got resource: %v", *pvs[0])
 	// return a copy of pv
 	return *pvs[0], nil
 }

--- a/pkg/policy/controller.go
+++ b/pkg/policy/controller.go
@@ -387,7 +387,6 @@ func (pc *PolicyController) processNextWorkItem() bool {
 		return false
 	}
 	defer pc.queue.Done(key)
-
 	err := pc.syncHandler(key.(string))
 	pc.handleErr(err, key)
 
@@ -451,11 +450,10 @@ func (pc *PolicyController) syncPolicy(key string) error {
 		return err
 	}
 	// process policies on existing resources
-	policyInfos := pc.processExistingResources(*p)
+	engineResponses := pc.processExistingResources(*p)
 	// report errors
-	pc.report(policyInfos)
+	pc.cleanupAndReport(engineResponses)
 	// fetch the policy again via the aggreagator to remain consistent
-	// return pc.statusAggregator.UpdateViolationCount(p.Name, pvList)
 	return pc.syncStatusOnly(p, pvList)
 }
 

--- a/pkg/policyviolation/controller.go
+++ b/pkg/policyviolation/controller.go
@@ -269,7 +269,7 @@ func (pvc *PolicyViolationController) syncBlockedResource(curPv *kyverno.Cluster
 
 		for _, resource := range resources.Items {
 			glog.V(4).Infof("getting owners for %s/%s/%s\n", resource.GetKind(), resource.GetNamespace(), resource.GetName())
-			owners := getOwners(pvc.client, resource)
+			owners := GetOwners(pvc.client, resource)
 			// owner of resource matches violation resourceSpec
 			// remove policy violation as the blocked request got created
 			if containsOwner(owners, curPv) {

--- a/pkg/policyviolation/helpers.go
+++ b/pkg/policyviolation/helpers.go
@@ -202,19 +202,6 @@ func converLabelToSelector(labelMap map[string]string) (labels.Selector, error) 
 	return policyViolationSelector, nil
 }
 
-type pvResourceOwner struct {
-	kind      string
-	namespace string
-	name      string
-}
-
-func (o pvResourceOwner) toKey() string {
-	if o.namespace == "" {
-		return o.kind + "." + o.name
-	}
-	return o.kind + "." + o.namespace + "." + o.name
-}
-
 //GetOwners pass in unstr rather than using the client to get the unstr
 // as if name is empty then GetResource panic as it returns a list
 func GetOwners(dclient *dclient.Client, unstr unstructured.Unstructured) []kyverno.ResourceSpec {

--- a/pkg/policyviolation/helpers.go
+++ b/pkg/policyviolation/helpers.go
@@ -281,26 +281,26 @@ func validDependantForDeployment(client appsv1.AppsV1Interface, curPv kyverno.Cl
 		return false
 	}
 
-	owner := pvResourceOwner{
-		kind:      curPv.Spec.ResourceSpec.Kind,
-		namespace: curPv.Spec.ResourceSpec.Namespace,
-		name:      curPv.Spec.ResourceSpec.Name,
+	owner := kyverno.ResourceSpec{
+		Kind:      curPv.Spec.ResourceSpec.Kind,
+		Namespace: curPv.Spec.ResourceSpec.Namespace,
+		Name:      curPv.Spec.ResourceSpec.Name,
 	}
 
-	deploy, err := client.Deployments(owner.namespace).Get(owner.name, metav1.GetOptions{})
+	deploy, err := client.Deployments(owner.Namespace).Get(owner.Name, metav1.GetOptions{})
 	if err != nil {
-		glog.Errorf("failed to get resourceOwner deployment %s/%s/%s: %v", owner.kind, owner.namespace, owner.name, err)
+		glog.Errorf("failed to get resourceOwner deployment %s/%s/%s: %v", owner.Kind, owner.Namespace, owner.Name, err)
 		return false
 	}
 
 	expectReplicaset, err := deployutil.GetNewReplicaSet(deploy, client)
 	if err != nil {
-		glog.Errorf("failed to get replicaset owned by %s/%s/%s: %v", owner.kind, owner.namespace, owner.name, err)
+		glog.Errorf("failed to get replicaset owned by %s/%s/%s: %v", owner.Kind, owner.Namespace, owner.Name, err)
 		return false
 	}
 
 	if reflect.DeepEqual(expectReplicaset, v1.ReplicaSet{}) {
-		glog.V(2).Infof("no replicaset found for deploy %s/%s/%s", owner.namespace, owner.kind, owner.name)
+		glog.V(2).Infof("no replicaset found for deploy %s/%s/%s", owner.Namespace, owner.Kind, owner.Name)
 		return false
 	}
 	var actualReplicaset *v1.ReplicaSet


### PR DESCRIPTION
- cleanup policy violations in policy controller
  - policy violation on resource 
  - policy violation on the owner of the resource( using getOwners function in policyviolation pkg)
- Expose `GetOwners` function in `policyviolation` pkg

additional changes:
- store the cache sync variable in struct for dynamic config
- remove type `pvResourceOwner` and replace it with `kyverno.ResourceSpec` as they have the same types and functionality.

fixes #458

There is some latency hit in the policy correction and policy violation removal. Created issue #463 to optimize.