### PR TITLE
refer informer cache in policy controller for mutatingwebhookconfigs

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,10 +74,7 @@ func main() {
 	}
 
 	// WERBHOOK REGISTRATION CLIENT
-	webhookRegistrationClient, err := webhookconfig.NewWebhookRegistrationClient(clientConfig, client, serverIP, int32(webhookTimeout))
-	if err != nil {
-		glog.Fatalf("Unable to register admission webhooks on cluster: %v\n", err)
-	}
+	webhookRegistrationClient := webhookconfig.NewWebhookRegistrationClient(clientConfig, client, serverIP, int32(webhookTimeout))
 
 	// KYVERNO CRD INFORMER
 	// watches CRD resources:
@@ -90,7 +87,6 @@ func main() {
 	// watches namespace resource
 	// - cache resync time: 10 seconds
 	kubeInformer := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Second)
-
 	// Configuration Data
 	// dyamically load the configuration from configMap
 	// - resource filters
@@ -113,7 +109,17 @@ func main() {
 	// - process policy on existing resources
 	// - status aggregator: recieves stats when a policy is applied
 	//					    & updates the policy status
-	pc, err := policy.NewPolicyController(pclient, client, pInformer.Kyverno().V1().ClusterPolicies(), pInformer.Kyverno().V1().ClusterPolicyViolations(), pInformer.Kyverno().V1().NamespacedPolicyViolations(), egen, kubeInformer.Admissionregistration().V1beta1().MutatingWebhookConfigurations(), webhookRegistrationClient, configData, pvgen, policyMetaStore)
+	pc, err := policy.NewPolicyController(pclient,
+		client,
+		pInformer.Kyverno().V1().ClusterPolicies(),
+		pInformer.Kyverno().V1().ClusterPolicyViolations(),
+		pInformer.Kyverno().V1().NamespacedPolicyViolations(),
+		kubeInformer.Admissionregistration().V1beta1().MutatingWebhookConfigurations(),
+		webhookRegistrationClient,
+		configData,
+		egen,
+		pvgen,
+		policyMetaStore)
 	if err != nil {
 		glog.Fatalf("error creating policy controller: %v\n", err)
 	}

--- a/pkg/webhookconfig/checker.go
+++ b/pkg/webhookconfig/checker.go
@@ -67,7 +67,7 @@ func (wrc *WebhookRegistrationClient) removeVerifyWebhookMutatingWebhookConfig()
 		mutatingConfig = config.VerifyMutatingWebhookConfigurationName
 	}
 	glog.V(4).Infof("removing webhook configuration %s", mutatingConfig)
-	err = wrc.registrationClient.MutatingWebhookConfigurations().Delete(mutatingConfig, &v1.DeleteOptions{})
+	err = wrc.client.DeleteResouce(MutatingWebhookConfigurationKind, "", mutatingConfig, false)
 	if errorsapi.IsNotFound(err) {
 		glog.V(4).Infof("verify webhook configuration %s, does not exits. not deleting", mutatingConfig)
 	} else if err != nil {

--- a/pkg/webhookconfig/policy.go
+++ b/pkg/webhookconfig/policy.go
@@ -118,7 +118,7 @@ func (wrc *WebhookRegistrationClient) removePolicyWebhookConfigurations() {
 		validatingConfig = config.PolicyValidatingWebhookConfigurationName
 	}
 	glog.V(4).Infof("removing webhook configuration %s", validatingConfig)
-	err = wrc.registrationClient.ValidatingWebhookConfigurations().Delete(validatingConfig, &v1.DeleteOptions{})
+	err = wrc.client.DeleteResouce(ValidatingWebhookConfigurationKind, "", validatingConfig, false)
 	if errorsapi.IsNotFound(err) {
 		glog.V(4).Infof("policy webhook configuration %s, does not exits. not deleting", validatingConfig)
 	} else if err != nil {
@@ -136,7 +136,7 @@ func (wrc *WebhookRegistrationClient) removePolicyWebhookConfigurations() {
 	}
 
 	glog.V(4).Infof("removing webhook configuration %s", mutatingConfig)
-	err = wrc.registrationClient.MutatingWebhookConfigurations().Delete(mutatingConfig, &v1.DeleteOptions{})
+	err = wrc.client.DeleteResouce(MutatingWebhookConfigurationKind, "", mutatingConfig, false)
 	if errorsapi.IsNotFound(err) {
 		glog.V(4).Infof("policy webhook configuration %s, does not exits. not deleting", mutatingConfig)
 	} else if err != nil {

--- a/pkg/webhookconfig/registration.go
+++ b/pkg/webhookconfig/registration.go
@@ -5,41 +5,38 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/nirmata/kyverno/pkg/config"
 	client "github.com/nirmata/kyverno/pkg/dclient"
 	admregapi "k8s.io/api/admissionregistration/v1beta1"
 	errorsapi "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	admregclient "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 	rest "k8s.io/client-go/rest"
+)
+
+const (
+	MutatingWebhookConfigurationKind   string = "MutatingWebhookConfiguration"
+	ValidatingWebhookConfigurationKind string = "ValidatingWebhookConfiguration"
 )
 
 // WebhookRegistrationClient is client for registration webhooks on cluster
 type WebhookRegistrationClient struct {
-	registrationClient *admregclient.AdmissionregistrationV1beta1Client
-	client             *client.Client
-	clientConfig       *rest.Config
+	client       *client.Client
+	clientConfig *rest.Config
 	// serverIP should be used if running Kyverno out of clutser
 	serverIP       string
 	timeoutSeconds int32
 }
 
 // NewWebhookRegistrationClient creates new WebhookRegistrationClient instance
-func NewWebhookRegistrationClient(clientConfig *rest.Config, client *client.Client, serverIP string, webhookTimeout int32) (*WebhookRegistrationClient, error) {
-	registrationClient, err := admregclient.NewForConfig(clientConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	glog.V(4).Infof("Registering webhook client using serverIP %s\n", serverIP)
-
+func NewWebhookRegistrationClient(
+	clientConfig *rest.Config,
+	client *client.Client,
+	serverIP string,
+	webhookTimeout int32) *WebhookRegistrationClient {
 	return &WebhookRegistrationClient{
-		registrationClient: registrationClient,
-		client:             client,
-		clientConfig:       clientConfig,
-		serverIP:           serverIP,
-		timeoutSeconds:     webhookTimeout,
-	}, nil
+		clientConfig:   clientConfig,
+		client:         client,
+		serverIP:       serverIP,
+		timeoutSeconds: webhookTimeout,
+	}
 }
 
 // Register creates admission webhooks configs on cluster
@@ -105,8 +102,7 @@ func (wrc *WebhookRegistrationClient) CreateResourceMutatingWebhookConfiguration
 		// clientConfig - service
 		config = wrc.constructMutatingWebhookConfig(caData)
 	}
-
-	_, err := wrc.registrationClient.MutatingWebhookConfigurations().Create(config)
+	_, err := wrc.client.CreateResource(MutatingWebhookConfigurationKind, "", *config, false)
 	if errorsapi.IsAlreadyExists(err) {
 		glog.V(4).Infof("resource mutating webhook configuration %s, already exists. not creating one", config.Name)
 		return nil
@@ -116,18 +112,6 @@ func (wrc *WebhookRegistrationClient) CreateResourceMutatingWebhookConfiguration
 		return err
 	}
 	return nil
-}
-
-//GetResourceMutatingWebhookConfiguration returns the MutatingWebhookConfiguration
-func (wrc *WebhookRegistrationClient) GetResourceMutatingWebhookConfiguration() (*admregapi.MutatingWebhookConfiguration, error) {
-	var name string
-	if wrc.serverIP != "" {
-		name = config.MutatingWebhookConfigurationDebugName
-	} else {
-		name = config.MutatingWebhookConfigurationName
-	}
-
-	return wrc.registrationClient.MutatingWebhookConfigurations().Get(name, v1.GetOptions{})
 }
 
 //registerPolicyValidatingWebhookConfiguration create a Validating webhook configuration for Policy CRD
@@ -153,7 +137,7 @@ func (wrc *WebhookRegistrationClient) createPolicyValidatingWebhookConfiguration
 	}
 
 	// create validating webhook configuration resource
-	if _, err := wrc.registrationClient.ValidatingWebhookConfigurations().Create(config); err != nil {
+	if _, err := wrc.client.CreateResource(ValidatingWebhookConfigurationKind, "", *config, false); err != nil {
 		return err
 	}
 
@@ -183,7 +167,7 @@ func (wrc *WebhookRegistrationClient) createPolicyMutatingWebhookConfiguration()
 	}
 
 	// create mutating webhook configuration resource
-	if _, err := wrc.registrationClient.MutatingWebhookConfigurations().Create(config); err != nil {
+	if _, err := wrc.client.CreateResource(MutatingWebhookConfigurationKind, "", *config, false); err != nil {
 		return err
 	}
 
@@ -213,7 +197,7 @@ func (wrc *WebhookRegistrationClient) createVerifyMutatingWebhookConfiguration()
 	}
 
 	// create mutating webhook configuration resource
-	if _, err := wrc.registrationClient.MutatingWebhookConfigurations().Create(config); err != nil {
+	if _, err := wrc.client.CreateResource(MutatingWebhookConfigurationKind, "", *config, false); err != nil {
 		return err
 	}
 

--- a/pkg/webhookconfig/resource.go
+++ b/pkg/webhookconfig/resource.go
@@ -58,16 +58,20 @@ func (wrc *WebhookRegistrationClient) constructMutatingWebhookConfig(caData []by
 	}
 }
 
+//GetResourceMutatingWebhookConfigName provi
+func (wrc *WebhookRegistrationClient) GetResourceMutatingWebhookConfigName() string {
+	if wrc.serverIP != "" {
+		return config.MutatingWebhookConfigurationDebugName
+	}
+	return config.MutatingWebhookConfigurationName
+}
+
 //RemoveResourceMutatingWebhookConfiguration removes mutating webhook configuration for all resources
 func (wrc *WebhookRegistrationClient) RemoveResourceMutatingWebhookConfiguration() error {
-	var configName string
-	if wrc.serverIP != "" {
-		configName = config.MutatingWebhookConfigurationDebugName
-	} else {
-		configName = config.MutatingWebhookConfigurationName
-	}
+
+	configName := wrc.GetResourceMutatingWebhookConfigName()
 	// delete webhook configuration
-	err := wrc.registrationClient.MutatingWebhookConfigurations().Delete(configName, &v1.DeleteOptions{})
+	err := wrc.client.DeleteResouce(MutatingWebhookConfigurationKind, "", configName, false)
 	if errors.IsNotFound(err) {
 		glog.V(4).Infof("resource webhook configuration %s does not exits, so not deleting", configName)
 		return nil


### PR DESCRIPTION
Each policy re-conciliation in policy controller was querying the client to check if the resource mutating webhook configuration is present or not, this check can be instead done on the local informer cache. 
Reduces the processes involved in a policy loop.

Also uses dynamic client, as we dont need to a typed client and makes api consistent.

fixes #506 