### PR TITLE
[WIP]mutation & validation stats not reported from policy controller

### DIFF
--- a/pkg/policy/apply.go
+++ b/pkg/policy/apply.go
@@ -17,43 +17,12 @@ import (
 //TODO: generation rules
 func applyPolicy(policy kyverno.ClusterPolicy, resource unstructured.Unstructured, policyStatus PolicyStatusInterface) (responses []engine.EngineResponse) {
 	startTime := time.Now()
-	var policyStats []PolicyStat
 	glog.V(4).Infof("Started apply policy %s on resource %s/%s/%s (%v)", policy.Name, resource.GetKind(), resource.GetNamespace(), resource.GetName(), startTime)
 	defer func() {
 		glog.V(4).Infof("Finished applying %s on resource %s/%s/%s (%v)", policy.Name, resource.GetKind(), resource.GetNamespace(), resource.GetName(), time.Since(startTime))
 	}()
 
-	// gather stats from the engine response
-	gatherStat := func(policyName string, policyResponse engine.PolicyResponse) {
-		ps := PolicyStat{}
-		ps.PolicyName = policyName
-		ps.Stats.MutationExecutionTime = policyResponse.ProcessingTime
-		ps.Stats.RulesAppliedCount = policyResponse.RulesAppliedCount
-		// capture rule level stats
-		for _, rule := range policyResponse.Rules {
-			rs := RuleStatinfo{}
-			rs.RuleName = rule.Name
-			rs.ExecutionTime = rule.RuleStats.ProcessingTime
-			if rule.Success {
-				rs.RuleAppliedCount++
-			} else {
-				rs.RulesFailedCount++
-			}
-			if rule.Patches != nil {
-				rs.MutationCount++
-			}
-			ps.Stats.Rules = append(ps.Stats.Rules, rs)
-		}
-		policyStats = append(policyStats, ps)
-	}
-	// send stats for aggregation
-	sendStat := func(blocked bool) {
-		for _, stat := range policyStats {
-			stat.Stats.ResourceBlocked = utils.Btoi(blocked)
-			//SEND
-			policyStatus.SendStat(stat)
-		}
-	}
+	// only stats from webhook are aggregated
 	var engineResponses []engine.EngineResponse
 	var engineResponse engine.EngineResponse
 	var err error
@@ -64,17 +33,10 @@ func applyPolicy(policy kyverno.ClusterPolicy, resource unstructured.Unstructure
 	if err != nil {
 		glog.Errorf("unable to process mutation rules: %v", err)
 	}
-	gatherStat(policy.Name, engineResponse.PolicyResponse)
-	//send stats
-	sendStat(false)
 
 	//VALIDATION
 	engineResponse = engine.Validate(engine.PolicyContext{Policy: policy, NewResource: resource})
 	engineResponses = append(engineResponses, engineResponse)
-	// gather stats
-	gatherStat(policy.Name, engineResponse.PolicyResponse)
-	//send stats
-	sendStat(false)
 
 	//TODO: GENERATION
 	return engineResponses


### PR DESCRIPTION
- Dont send stats for mutation & validation from controller evaluations
Pending:
- Handle evaluation of generate rules as it operates via a controller and currently there is no way to differentiate the initial evaluation and re-sync evaluations.

fixes #527 