### PR TITLE
implement quantity comparison

### DIFF
--- a/pkg/engine/pattern_test.go
+++ b/pkg/engine/pattern_test.go
@@ -257,7 +257,6 @@ func TestValidateNumberWithStr_LessFloatAndInt(t *testing.T) {
 func TestValidateQuantity_InvalidQuantity(t *testing.T) {
 	assert.Assert(t, !validateNumberWithStr("1024Gi", "", Equal))
 	assert.Assert(t, !validateNumberWithStr("gii", "1024Gi", Equal))
-	assert.Assert(t, !validateNumberWithStr(1024, "1024Gi", Equal))
 }
 
 func TestValidateQuantity_Equal(t *testing.T) {
@@ -266,6 +265,7 @@ func TestValidateQuantity_Equal(t *testing.T) {
 	assert.Assert(t, validateNumberWithStr("0.2", "200m", Equal))
 	assert.Assert(t, validateNumberWithStr("500", "500", Equal))
 	assert.Assert(t, !validateNumberWithStr("2048", "1024", Equal))
+	assert.Assert(t, validateNumberWithStr(1024, "1024", Equal))
 }
 
 func TestValidateQuantity_Operation(t *testing.T) {

--- a/pkg/engine/pattern_test.go
+++ b/pkg/engine/pattern_test.go
@@ -152,6 +152,10 @@ func TestValidateValueWithPattern_StringsLogicalOr(t *testing.T) {
 	assert.Assert(t, ValidateValueWithPattern(value, pattern))
 }
 
+func TestValidateValueWithPattern_EqualTwoFloats(t *testing.T) {
+	assert.Assert(t, ValidateValueWithPattern(7.0, 7.000))
+}
+
 func TestValidateValueWithNilPattern_NullPatternStringValue(t *testing.T) {
 	assert.Assert(t, !validateValueWithNilPattern("value"))
 }
@@ -242,32 +246,36 @@ func TestGetNumberAndStringPartsFromPattern_Empty(t *testing.T) {
 	assert.Equal(t, str, "")
 }
 
-func TestValidateNumber_EqualTwoFloats(t *testing.T) {
-	assert.Assert(t, validateNumber(7.0, 7.000, Equal))
+func TestValidateNumberWithStr_LessFloatAndInt(t *testing.T) {
+	assert.Assert(t, validateNumberWithStr(7.00001, "7.000001", More))
+	assert.Assert(t, validateNumberWithStr(7.00001, "7", NotEqual))
+
+	assert.Assert(t, validateNumberWithStr(7.0000, "7", Equal))
+	assert.Assert(t, !validateNumberWithStr(6.000000001, "6", Less))
 }
 
-func TestValidateNumber_LessFloatAndInt(t *testing.T) {
-	assert.Assert(t, validateNumber(7, 7.00001, Less))
-	assert.Assert(t, validateNumber(7, 7.00001, NotEqual))
-
-	assert.Assert(t, !validateNumber(7, 7.0000, NotEqual))
-	assert.Assert(t, !validateNumber(6, 6.000000001, More))
+func TestValidateQuantity_InvalidQuantity(t *testing.T) {
+	assert.Assert(t, !validateNumberWithStr("1024Gi", "", Equal))
+	assert.Assert(t, !validateNumberWithStr("gii", "1024Gi", Equal))
+	assert.Assert(t, !validateNumberWithStr(1024, "1024Gi", Equal))
 }
 
-func TestValidateNumberWithStr_Equal(t *testing.T) {
-	assert.Assert(t, validateNumberWithStr("1024Gi", "1024", "Gi", Equal))
+func TestValidateQuantity_Equal(t *testing.T) {
+	assert.Assert(t, validateNumberWithStr("1024Gi", "1024Gi", Equal))
+	assert.Assert(t, validateNumberWithStr("1024Mi", "1Gi", Equal))
+	assert.Assert(t, validateNumberWithStr("0.2", "200m", Equal))
+	assert.Assert(t, validateNumberWithStr("500", "500", Equal))
+	assert.Assert(t, !validateNumberWithStr("2048", "1024", Equal))
 }
 
-func TestValidateNumberWithStr_More(t *testing.T) {
-	assert.Assert(t, !validateNumberWithStr("512Gi", "1024", "Gi", More))
-}
-
-func TestValidateNumberWithStr_MoreAndWildCard(t *testing.T) {
-	assert.Assert(t, validateNumberWithStr("2048Gi", "1024", "G?", More))
-}
-
-func TestValidateNumberWithStr_NoStr(t *testing.T) {
-	assert.Assert(t, validateNumberWithStr(2048, "1024", "", More))
+func TestValidateQuantity_Operation(t *testing.T) {
+	assert.Assert(t, validateNumberWithStr("1Gi", "1000Mi", More))
+	assert.Assert(t, validateNumberWithStr("1G", "1Gi", Less))
+	assert.Assert(t, validateNumberWithStr("500m", "0.5", MoreEqual))
+	assert.Assert(t, validateNumberWithStr("1", "500m", MoreEqual))
+	assert.Assert(t, validateNumberWithStr("0.5", ".5", LessEqual))
+	assert.Assert(t, validateNumberWithStr("0.2", ".5", LessEqual))
+	assert.Assert(t, validateNumberWithStr("0.2", ".5", NotEqual))
 }
 
 func TestGetOperatorFromStringPattern_OneChar(t *testing.T) {

--- a/pkg/engine/utils.go
+++ b/pkg/engine/utils.go
@@ -318,25 +318,19 @@ func removeAnchor(key string) string {
 	return key
 }
 
-// convertToFloat converts string and any other value to float64
-func convertToFloat(value interface{}) (float64, error) {
+// convertToString converts value to string
+func convertToString(value interface{}) (string, error) {
 	switch typed := value.(type) {
 	case string:
-		var err error
-		floatValue, err := strconv.ParseFloat(typed, 64)
-		if err != nil {
-			return 0, err
-		}
-
-		return floatValue, nil
+		return string(typed), nil
 	case float64:
-		return typed, nil
+		return fmt.Sprintf("%f", typed), nil
 	case int64:
-		return float64(typed), nil
+		return strconv.FormatInt(typed, 10), nil
 	case int:
-		return float64(typed), nil
+		return strconv.Itoa(typed), nil
 	default:
-		return 0, fmt.Errorf("Could not convert %T to float64", value)
+		return "", fmt.Errorf("Could not convert %T to string", value)
 	}
 }
 


### PR DESCRIPTION
Fix #428.

In order to handle quantity comparison (`pattern` in a rule is defined with string, e.g. "1Gi"), we first parse the pattern:
- if it's with type quantity, then compare by the quantities
- if it's a normal string, then a wildcard match