### PR TITLE
fix mutation patch bytes

### DIFF
--- a/pkg/engine/overlay.go
+++ b/pkg/engine/overlay.go
@@ -280,7 +280,7 @@ func applyOverlayToArrayOfMaps(resource, overlay []interface{}, path string) ([]
 
 		if len(anchors) > 0 {
 			// If we have anchors - choose corresponding resource element and mutate it
-			patches, err := applyOverlayWithAnchors(resource, overlayElement, anchors, path)
+			patches, err := applyOverlayWithAnchors(resource, overlayElement, path)
 			if err != nil {
 				return nil, err
 			}
@@ -311,21 +311,17 @@ func applyOverlayToArrayOfMaps(resource, overlay []interface{}, path string) ([]
 	return appliedPatches, nil
 }
 
-func applyOverlayWithAnchors(resource []interface{}, overlay interface{}, anchors map[string]interface{}, path string) ([][]byte, error) {
+func applyOverlayWithAnchors(resource []interface{}, overlay interface{}, path string) ([][]byte, error) {
 	var appliedPatches [][]byte
 
 	for i, resourceElement := range resource {
-		typedResource := resourceElement.(map[string]interface{})
-
 		currentPath := path + strconv.Itoa(i) + "/"
 		// currentPath example: /spec/template/spec/containers/3/
-		if !skipArrayObject(typedResource, anchors) {
-			patches, err := applyOverlay(resourceElement, overlay, currentPath)
-			if err != nil {
-				return nil, err
-			}
-			appliedPatches = append(appliedPatches, patches...)
+		patches, err := applyOverlay(resourceElement, overlay, currentPath)
+		if err != nil {
+			return nil, err
 		}
+		appliedPatches = append(appliedPatches, patches...)
 	}
 
 	return appliedPatches, nil


### PR DESCRIPTION
In the mutation, there are 2 iterations, the first would check the matched conditions, and only if they match, we will generate patch bytes in the second iteration.
This PR removes condition check while generating mutation patch, as conditions are already verified in the first iteration.