### PR TITLE
Fixes

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -256,7 +256,7 @@ func cleanupOldCrd(client *dclient.Client) {
 	gvr := client.DiscoveryClient.GetGVRFromKind("NamespacedPolicyViolation")
 	if !reflect.DeepEqual(gvr, (schema.GroupVersionResource{})) {
 		if err := client.DeleteResource("CustomResourceDefinition", "", "namespacedpolicyviolations.kyverno.io", false); err != nil {
-			glog.Info("Failed to remove previous CRD namespacedpolicyviolations: %v", err)
+			glog.Infof("Failed to remove previous CRD namespacedpolicyviolations: %v", err)
 		}
 	}
 }

--- a/pkg/policy/controller.go
+++ b/pkg/policy/controller.go
@@ -227,6 +227,12 @@ func (pc *PolicyController) Run(workers int, stopCh <-chan struct{}) {
 		glog.Error("failed to sync informer cache")
 		return
 	}
+
+	// if policies exist before Kyverno get created, resource webhook configuration
+	// could not be registered as clusterpolicy.spec.background=false by default
+	// the policy controller would starts only when the first incoming policy is queued
+	pc.registerResourceWebhookConfiguration()
+
 	for i := 0; i < workers; i++ {
 		go wait.Until(pc.worker, time.Second, stopCh)
 	}

--- a/pkg/policy/controller.go
+++ b/pkg/policy/controller.go
@@ -228,11 +228,6 @@ func (pc *PolicyController) Run(workers int, stopCh <-chan struct{}) {
 		return
 	}
 
-	// if policies exist before Kyverno get created, resource webhook configuration
-	// could not be registered as clusterpolicy.spec.background=false by default
-	// the policy controller would starts only when the first incoming policy is queued
-	pc.registerResourceWebhookConfiguration()
-
 	for i := 0; i < workers; i++ {
 		go wait.Until(pc.worker, time.Second, stopCh)
 	}
@@ -250,6 +245,11 @@ func (pc *PolicyController) worker() {
 }
 
 func (pc *PolicyController) processNextWorkItem() bool {
+	// if policies exist before Kyverno get created, resource webhook configuration
+	// could not be registered as clusterpolicy.spec.background=false by default
+	// the policy controller would starts only when the first incoming policy is queued
+	pc.registerResourceWebhookConfiguration()
+
 	key, quit := pc.queue.Get()
 	if quit {
 		return false

--- a/pkg/policy/webhookregistration.go
+++ b/pkg/policy/webhookregistration.go
@@ -29,6 +29,18 @@ func (pc *PolicyController) removeResourceWebhookConfiguration() error {
 	return nil
 }
 
+func (pc *PolicyController) registerResourceWebhookConfiguration() {
+	policies, err := pc.pLister.List(labels.NewSelector())
+	if err != nil {
+		glog.Errorf("failed to register resource webhook configuration, error listing policies: %v", err)
+	}
+
+	if hasMutateOrValidatePolicies(policies) {
+		glog.V(4).Info("Found existing policy, registering resource webhook configuration")
+		pc.resourceWebhookWatcher.RegisterResourceWebhook()
+	}
+}
+
 func hasMutateOrValidatePolicies(policies []*kyverno.ClusterPolicy) bool {
 	for _, policy := range policies {
 		if (*policy).HasMutateOrValidate() {

--- a/pkg/policyviolation/generator.go
+++ b/pkg/policyviolation/generator.go
@@ -133,6 +133,7 @@ func (gen *Generator) enqueue(info Info) {
 func (gen *Generator) Add(infos ...Info) {
 	for _, info := range infos {
 		gen.enqueue(info)
+		glog.V(3).Infof("Added policy violation: %s", info.toKey())
 	}
 }
 
@@ -234,9 +235,13 @@ func (gen *Generator) syncHandler(info Info) error {
 	pvs := builder.generate(info)
 	for _, pv := range pvs {
 		// Create Policy Violations
+		glog.V(3).Infof("Creating policy violation: %s", info.toKey())
 		err := handler.create(pv)
 		if err != nil {
 			failure = true
+			glog.V(3).Infof("Failed to create policy violation: %v", err)
+		} else {
+			glog.V(3).Infof("Policy violation created: %s", info.toKey())
 		}
 	}
 	if failure {

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -68,7 +68,7 @@ func CRDInstalled(discovery client.IDiscovery) bool {
 		glog.Infof("CRD %s found ", kind)
 		return true
 	}
-	if !check("ClusterPolicy") || !check("ClusterPolicyViolation") {
+	if !check("ClusterPolicy") || !check("ClusterPolicyViolation") || !check("PolicyViolation") {
 		return false
 	}
 	return true


### PR DESCRIPTION
These PR fixes a few issues:
- cleanup old CRD `namespacedpolicyviolation` when Kyverno starts
- register resource webhook configuration when policy controller starts: if policies present prior to Kyverno get installed, the resource webhook won't be registered if there is no policy with background flag enabled (controller starts until the first policy with background flag pushed to the queue) -- To be removed after #566 fixed.