### PR TITLE
update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ spec:
     generate:
       kind: ConfigMap
       name: zk-kafka-address
+      # create the resource in the new namespace
+      namespace: "{{request.object.name}}"
       data:
         kind: ConfigMap
         data:

--- a/documentation/writing-policies.md
+++ b/documentation/writing-policies.md
@@ -76,7 +76,7 @@ spec :
       - key: name # compares (key operator value) 
         operator: Equal
         value: name # constant "name" == "name"
-      - key: "{{serviceAccount}}" # refer to a pre-defined variable serviceAccount
+      - key: "{{serviceAccountName}}" # refer to a pre-defined variable serviceAccountName
         operator: NotEqual
         value: "user1" # if service 
      # Each rule can contain a single validate, mutate, or generate directive


### PR DESCRIPTION
In the example policy, we specify the namespace the new resource is to be created in.
This is required now as the `generate` rule can also create cluster-wide resources.
