### PR TITLE
Default failurepolicy & bug fix

### DIFF
--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -156,7 +156,7 @@ var podTemplateRule = kyverno.Rule{
 				"template": map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"annotations": map[string]interface{}{
-							"pod-policies.kyverno.io/autogen-applied": "true",
+							"+(pod-policies.kyverno.io/autogen-applied)": "true",
 						},
 					},
 				},

--- a/pkg/engine/utils/utils.go
+++ b/pkg/engine/utils/utils.go
@@ -25,11 +25,12 @@ func (ri RuleType) String() string {
 }
 
 // ApplyPatches patches given resource with given patches and returns patched document
+// return origin resource if any error occurs
 func ApplyPatches(resource []byte, patches [][]byte) ([]byte, error) {
 	joinedPatches := JoinPatches(patches)
 	patch, err := jsonpatch.DecodePatch(joinedPatches)
 	if err != nil {
-		return nil, err
+		return resource, err
 	}
 
 	patchedDocument, err := patch.Apply(resource)

--- a/pkg/webhookconfig/common.go
+++ b/pkg/webhookconfig/common.go
@@ -63,6 +63,7 @@ func (wrc *WebhookRegistrationClient) constructOwner() v1.OwnerReference {
 
 func generateDebugWebhook(name, url string, caData []byte, validate bool, timeoutSeconds int32, resource, apiGroups, apiVersions string, operationTypes []admregapi.OperationType) admregapi.Webhook {
 	sideEffect := admregapi.SideEffectClassNoneOnDryRun
+	failurePolicy := admregapi.Ignore
 	return admregapi.Webhook{
 		Name: name,
 		ClientConfig: admregapi.WebhookClientConfig{
@@ -88,11 +89,13 @@ func generateDebugWebhook(name, url string, caData []byte, validate bool, timeou
 		},
 		AdmissionReviewVersions: []string{"v1beta1"},
 		TimeoutSeconds:          &timeoutSeconds,
+		FailurePolicy:           &failurePolicy,
 	}
 }
 
 func generateWebhook(name, servicePath string, caData []byte, validation bool, timeoutSeconds int32, resource, apiGroups, apiVersions string, operationTypes []admregapi.OperationType) admregapi.Webhook {
 	sideEffect := admregapi.SideEffectClassNoneOnDryRun
+	failurePolicy := admregapi.Ignore
 	return admregapi.Webhook{
 		Name: name,
 		ClientConfig: admregapi.WebhookClientConfig{
@@ -122,5 +125,6 @@ func generateWebhook(name, servicePath string, caData []byte, validation bool, t
 		},
 		AdmissionReviewVersions: []string{"v1beta1"},
 		TimeoutSeconds:          &timeoutSeconds,
+		FailurePolicy:           &failurePolicy,
 	}
 }

--- a/pkg/webhooks/mutation.go
+++ b/pkg/webhooks/mutation.go
@@ -91,6 +91,8 @@ func (ws *WebhookServer) HandleMutation(request *v1beta1.AdmissionRequest, resou
 		// gather patches
 		patches = append(patches, engineResponse.GetPatches()...)
 		glog.V(4).Infof("Mutation from policy %s has applied succesfully to %s %s/%s", policy.Name, request.Kind.Kind, resource.GetNamespace(), resource.GetName())
+
+		policyContext.NewResource = engineResponse.PatchedResource
 	}
 
 	// generate annotations

--- a/samples/best_practices/disallow_default_namespace.yaml
+++ b/samples/best_practices/disallow_default_namespace.yaml
@@ -3,6 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: disallow-default-namespace
   annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/category: Workload Isolation
     policies.kyverno.io/description: Kubernetes namespaces are an optional feature 
       that provide a way to segment and isolate cluster resources across multiple 


### PR DESCRIPTION
This PR 
- fix #631, set failurepolicy of webhookconfiguration to `Ignore`
- for the same admission request, fix to pass in patchedResource for mutation
- update policy annotation