### PR TITLE
mutation failure should not block resource creation

### DIFF
--- a/pkg/engine/mutate/overlay.go
+++ b/pkg/engine/mutate/overlay.go
@@ -374,7 +374,6 @@ func processSubtree(overlay interface{}, path string, op string) ([]byte, error)
 	// check the patch
 	_, err := jsonpatch.DecodePatch([]byte("[" + patchStr + "]"))
 	if err != nil {
-		glog.V(3).Info(err)
 		return nil, fmt.Errorf("Failed to make '%s' patch from an overlay '%s' for path %s, err: %v", op, value, path, err)
 	}
 

--- a/pkg/engine/mutation.go
+++ b/pkg/engine/mutation.go
@@ -143,8 +143,7 @@ func startMutateResultResponse(resp *response.EngineResponse, policy kyverno.Clu
 	resp.PolicyResponse.Resource.Namespace = resource.GetNamespace()
 	resp.PolicyResponse.Resource.Kind = resource.GetKind()
 	resp.PolicyResponse.Resource.APIVersion = resource.GetAPIVersion()
-	// TODO: replace with mutationFailureAction ?
-	resp.PolicyResponse.ValidationFailureAction = policy.Spec.ValidationFailureAction
+	// TODO(shuting): set response with mutationFailureAction
 }
 
 func endMutateResultResponse(resp *response.EngineResponse, startTime time.Time) {

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -74,7 +74,6 @@ func startResultResponse(resp *response.EngineResponse, policy kyverno.ClusterPo
 	resp.PolicyResponse.Resource.Kind = newR.GetKind()
 	resp.PolicyResponse.Resource.APIVersion = newR.GetAPIVersion()
 	resp.PolicyResponse.ValidationFailureAction = policy.Spec.ValidationFailureAction
-
 }
 
 func endResultResponse(resp *response.EngineResponse, startTime time.Time) {

--- a/pkg/webhooks/common.go
+++ b/pkg/webhooks/common.go
@@ -36,6 +36,26 @@ func toBlockResource(engineReponses []response.EngineResponse) bool {
 	return false
 }
 
+// getEnforceFailureErrorMsg gets the error messages for failed enforce policy
+func getEnforceFailureErrorMsg(engineReponses []response.EngineResponse) string {
+	var str []string
+	var resourceInfo string
+
+	for _, er := range engineReponses {
+		if !er.IsSuccesful() && er.PolicyResponse.ValidationFailureAction == Enforce {
+			resourceInfo = fmt.Sprintf("%s/%s/%s", er.PolicyResponse.Resource.Kind, er.PolicyResponse.Resource.Namespace, er.PolicyResponse.Resource.Name)
+			str = append(str, fmt.Sprintf("failed policy %s:", er.PolicyResponse.Policy))
+			for _, rule := range er.PolicyResponse.Rules {
+				if !rule.Success {
+					str = append(str, rule.ToString())
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("Resource %s %s", resourceInfo, strings.Join(str, ";"))
+}
+
+// getErrorMsg gets all failed engine response message
 func getErrorMsg(engineReponses []response.EngineResponse) string {
 	var str []string
 	var resourceInfo string

--- a/pkg/webhooks/common.go
+++ b/pkg/webhooks/common.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// isResponseSuccesful return true if all responses are successful
 func isResponseSuccesful(engineReponses []response.EngineResponse) bool {
 	for _, er := range engineReponses {
 		if !er.IsSuccesful() {

--- a/pkg/webhooks/mutation.go
+++ b/pkg/webhooks/mutation.go
@@ -119,7 +119,7 @@ func (ws *WebhookServer) HandleMutation(request *v1beta1.AdmissionRequest, resou
 	// debug info
 	func() {
 		if len(patches) != 0 {
-			glog.V(3).Infof("Patches generated for %s/%s/%s, operation=%v:\n %v",
+			glog.V(4).Infof("Patches generated for %s/%s/%s, operation=%v:\n %v",
 				resource.GetKind(), resource.GetNamespace(), resource.GetName(), request.Operation, string(engineutils.JoinPatches(patches)))
 		}
 

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -235,23 +235,15 @@ func (ws *WebhookServer) handleAdmissionRequest(request *v1beta1.AdmissionReques
 	}
 
 	// MUTATION
-	ok, patches, msg := ws.HandleMutation(request, resource, policies, roles, clusterRoles)
-	if !ok {
-		glog.V(4).Infof("Deny admission request:  %v/%s/%s", request.Kind, request.Namespace, request.Name)
-		return &v1beta1.AdmissionResponse{
-			Allowed: false,
-			Result: &metav1.Status{
-				Status:  "Failure",
-				Message: msg,
-			},
-		}
-	}
+	// mutation failure should not block the resource creation
+	// any mutation failure is reported as the violation
+	patches := ws.HandleMutation(request, resource, policies, roles, clusterRoles)
 
 	// patch the resource with patches before handling validation rules
 	patchedResource := processResourceWithPatches(patches, request.Object.Raw)
 
 	// VALIDATION
-	ok, msg = ws.HandleValidation(request, policies, patchedResource, roles, clusterRoles)
+	ok, msg := ws.HandleValidation(request, policies, patchedResource, roles, clusterRoles)
 	if !ok {
 		glog.V(4).Infof("Deny admission request: %v/%s/%s", request.Kind, request.Namespace, request.Name)
 		return &v1beta1.AdmissionResponse{

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -237,17 +237,7 @@ func (ws *WebhookServer) handleAdmissionRequest(request *v1beta1.AdmissionReques
 	// MUTATION
 	// mutation failure should not block the resource creation
 	// any mutation failure is reported as the violation
-	blocked, patches, errMsg := ws.HandleMutation(request, resource, policies, roles, clusterRoles)
-	if blocked {
-		glog.V(4).Infof("Deny admission request:  %v/%s/%s", request.Kind, request.Namespace, request.Name)
-		return &v1beta1.AdmissionResponse{
-			Allowed: false,
-			Result: &metav1.Status{
-				Status:  "Failure",
-				Message: errMsg,
-			},
-		}
-	}
+	patches := ws.HandleMutation(request, resource, policies, roles, clusterRoles)
 
 	// patch the resource with patches before handling validation rules
 	patchedResource := processResourceWithPatches(patches, request.Object.Raw)

--- a/pkg/webhooks/validation.go
+++ b/pkg/webhooks/validation.go
@@ -107,7 +107,7 @@ func (ws *WebhookServer) HandleValidation(request *v1beta1.AdmissionRequest, pol
 	if blocked {
 		glog.V(4).Infof("resource %s/%s/%s is blocked\n", newR.GetKind(), newR.GetNamespace(), newR.GetName())
 		sendStat(true)
-		return false, getErrorMsg(engineResponses)
+		return false, getEnforceFailureErrorMsg(engineResponses)
 	}
 
 	// ADD POLICY VIOLATIONS


### PR DESCRIPTION
This PR fix #627, #636.

Mutation failure is only reported as a violation in this fix. The resource creation would not be blocked if any error occurs.

Further support can be tracked in #639.