### PR TITLE
add kubernetes server version check

### DIFF
--- a/cmd/initContainer/main.go
+++ b/cmd/initContainer/main.go
@@ -222,21 +222,21 @@ func isVersionSupported(client *client.Client) {
 	exp := regexp.MustCompile(`v(\d*).(\d*).(\d*)`)
 	groups := exp.FindAllStringSubmatch(serverVersion.String(), -1)
 	if len(groups) != 1 || len(groups[0]) != 4 {
-		glog.Fatalf("Failed to extract kubernetes server version: %v\n", serverVersion, err)
+		glog.Fatalf("Failed to extract kubernetes server version: %v.err %v\n", serverVersion, err)
 	}
 	// convert string to int
 	// assuming the version are always intergers
 	major, err := strconv.Atoi(groups[0][1])
 	if err != nil {
-		glog.Fatalf("Failed to extract kubernetes major server version: %v\n", serverVersion, err)
+		glog.Fatalf("Failed to extract kubernetes major server version: %v.err %v\n", serverVersion, err)
 	}
 	minor, err := strconv.Atoi(groups[0][2])
 	if err != nil {
-		glog.Fatalf("Failed to extract kubernetes minor server version: %v\n", serverVersion, err)
+		glog.Fatalf("Failed to extract kubernetes minor server version: %v.err %v\n", serverVersion, err)
 	}
 	sub, err := strconv.Atoi(groups[0][3])
 	if err != nil {
-		glog.Fatalf("Failed to extract kubernetes sub minor server version: %v\n", serverVersion, err)
+		glog.Fatalf("Failed to extract kubernetes sub minor server version:%v. err %v\n", serverVersion, err)
 	}
 	if major <= 1 && minor <= 12 && sub < 7 {
 		glog.Fatalf("Unsupported kubernetes server version %s. Kyverno is supported from version v1.12.7+", serverVersion)

--- a/pkg/dclient/client.go
+++ b/pkg/dclient/client.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	patchTypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
@@ -213,6 +214,7 @@ func convertToCSR(obj *unstructured.Unstructured) (*certificates.CertificateSign
 //IDiscovery provides interface to mange Kind and GVR mapping
 type IDiscovery interface {
 	GetGVRFromKind(kind string) schema.GroupVersionResource
+	GetServerVersion() (*version.Info, error)
 }
 
 // SetDiscovery sets the discovery client implementation
@@ -263,6 +265,11 @@ func (c ServerPreferredResources) GetGVRFromKind(kind string) schema.GroupVersio
 		}
 	}
 	return gvr
+}
+
+//GetServerVersion returns the server version of the cluster
+func (c ServerPreferredResources) GetServerVersion() (*version.Info, error) {
+	return c.cachedClient.ServerVersion()
 }
 
 func loadServerResources(k string, cdi discovery.CachedDiscoveryInterface) (schema.GroupVersionResource, error) {

--- a/pkg/dclient/utils.go
+++ b/pkg/dclient/utils.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic/fake"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 )
@@ -62,6 +63,10 @@ func (c *fakeDiscoveryClient) getGVR(resource string) schema.GroupVersionResourc
 		}
 	}
 	return schema.GroupVersionResource{}
+}
+
+func (c *fakeDiscoveryClient) GetServerVersion() (*version.Info, error) {
+	return nil, nil
 }
 
 func (c *fakeDiscoveryClient) GetGVRFromKind(kind string) schema.GroupVersionResource {


### PR DESCRIPTION
- Add a check-in InitContainer to exit if the kubernetes server version is  < v1.12.7.

Tested with minikube versions(v1.12.6[fail] & v1.12.7[pass])

