### PR TITLE
Add Helm chart for Kyverno - #835

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: kyverno
+version: 0.0.1
+appVersion: v1.1.5
+description: Kubernetes Native Policy Management
+keywords:
+  - kubernetes
+  - nirmata
+  - policy agent
+  - validating webhook
+  - admissions controller
+home: https://kyverno.io/
+sources:
+  - https://github.com/nirmata/kyverno
+maintainers:
+  - name: Nirmata
+    url: https://kyverno.io/
+engine: gotpl
+kubeVersion: ">=1.10.0-0"

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -11,7 +11,7 @@
 ## TL;DR;
 
 ```console
-$ helm install -n kyverno ./kyverno
+$ helm install --create-namespace -n kyverno kyverno ./kyverno
 ```
 
 ## Introduction
@@ -23,8 +23,10 @@ This chart bootstraps a Kyverno deployment on a [Kubernetes](http://kubernetes.i
 Kyverno makes assumptions about naming of namespaces and resources. Therefore, the chart must be installed with the default release name `kyverno` (default if --name is omitted) and in the namespace 'kyverno':
 
 ```console
-$ helm install --namespace kyverno --name kyverno ./kyverno
+$ helm install --namespace kyverno kyverno ./kyverno
 ```
+
+Note that Helm by default expects the namespace to already exist before running helm install. If you want Helm to create the namespace, add --create-namespace to the command.
 
 The command deploys kyverno on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
@@ -33,7 +35,7 @@ The command deploys kyverno on the Kubernetes cluster in the default configurati
 To uninstall/delete the `kyverno` deployment:
 
 ```console
-$ helm delete -n kyverno
+$ helm delete -n kyverno kyverno
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -83,14 +85,14 @@ Parameter | Description | Default
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --namespace kyverno --name kyverno ./kyverno \
+$ helm install --namespace kyverno kyverno ./kyverno \
   --set=image.tag=v0.0.2,resources.limits.cpu=200m
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --namespace kyverno --name kyverno ./kyverno -f values.yaml
+$ helm install --namespace kyverno kyverno ./kyverno -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -1,0 +1,102 @@
+# kyverno
+
+[Kyverno](https://kyverno.io) is a Kubernetes Native Policy Management engine. It allows you to
+
+* Manage policies as Kubernetes resources.
+* Validate, mutate, and generate configurations.
+* Select resources based on labels and wildcards.
+* View policy enforcement as events.
+* Detect policy violations for existing resources.
+
+## TL;DR;
+
+```console
+$ helm install -n kyverno ./kyverno
+```
+
+## Introduction
+
+This chart bootstraps a Kyverno deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+Kyverno makes assumptions about naming of namespaces and resources. Therefore, the chart must be installed with the default release name `kyverno` (default if --name is omitted) and in the namespace 'kyverno':
+
+```console
+$ helm install --namespace kyverno --name kyverno ./kyverno
+```
+
+The command deploys kyverno on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `kyverno` deployment:
+
+```console
+$ helm delete -n kyverno
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the kyverno chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`affinity` | node/pod affinities | `nil`
+`createSelfSignedCert` | generate a self signed cert and certificate authority. Kyverno defaults to using kube-controller-manager CA-signed certificate or existing cert secret if false. | `false`
+`config.existingConfig` | existing Kubernetes configmap to use for the resource filters configuration | `nil`
+`config.resourceFilters` | list of filter of resource types to be skipped by kyverno policy engine. See [documentation](https://github.com/nirmata/kyverno/blob/master/documentation/installation.md#filter-kubernetes-resources-that-admission-webhook-should-not-process) for details | `["[Event,*,*]","[*,kube-system,*]","[*,kube-public,*]","[*,kube-node-lease,*]","[Node,*,*]","[APIService,*,*]","[TokenReview,*,*]","[SubjectAccessReview,*,*]","[*,kyverno,*]"]`
+`extraArgs` | list of extra arguments to give the binary | `[]`
+`fullnameOverride` | override the expanded name of the chart | `nil`
+`generatecontrollerExtraResources` | extra resource type Kyverno is allowed to generate | `[]`
+`image.pullPolicy` | Image pull policy | `IfNotPresent`
+`image.pullSecrets` | Specify image pull secrets | `[]` (does not add image pull secrets to deployed pods)
+`image.repository` | Image repository | `nirmata/kyverno`
+`image.tag` | Image tag | `nil`
+`initImage.pullPolicy` | Init image pull policy | `nil`
+`initImage.repository` | Init image repository | `nirmata/kyvernopre`
+`initImage.tag` | Init image tag | `nil`
+`livenessProbe` | liveness probe configuration | `{}`
+`nameOverride` | override the name of the chart | `nil`
+`nodeSelector` | node labels for pod assignment | `{}`
+`podAnnotations` | annotations to add to each pod | `{}`
+`podLabels` | additional labels to add to each pod | `{}`
+`podSecurityContext` | security context for the pod | `{}`
+`priorityClassName` | priorityClassName | `nil`
+`rbac.create` | create cluster roles, cluster role bindings, and service account | `true`
+`rbac.serviceAccount.create` | create a service account | `true`
+`rbac.serviceAccount.name` | the service account name | `nil`
+`rbac.serviceAccount.annotations` | annotations for the service account | `{}`
+`readinessProbe` | readiness probe configuration | `{}`
+`replicaCount` | desired number of pods | `1`
+`resources` | pod resource requests & limits | `{}`
+`service.annotations` | annotations to add to the service | `{}`
+`service.nodePort` | node port | `nil`
+`service.port` | port for the service | `443`
+`service.type` | type of service | `ClusterIP`
+`tolerations` | list of node taints to tolerate | `[]`
+`securityContext` | security context configuration | `{}`
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --namespace kyverno --name kyverno ./kyverno \
+  --set=image.tag=v0.0.2,resources.limits.cpu=200m
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --namespace kyverno --name kyverno ./kyverno -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## TLS Configuration
+
+If `createSelfSignedCert` is `true`, Helm will take care of the steps of creating an external self-signed certificate describe in option 2 of the [installation documentation](https://github.com/nirmata/kyverno/blob/master/documentation/installation.md#option-2-use-your-own-ca-signed-certificate)
+
+If `createSelfSignedCert` is `false`, Kyverno will generate a pair using the kube-controller-manager., or you can provide your own TLS CA and signed-key pair and create the secret yourself as described in the documentation.

--- a/charts/kyverno/crds/crds.yaml
+++ b/charts/kyverno/crds/crds.yaml
@@ -1,0 +1,446 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterpolicies.kyverno.io
+spec:
+  group: kyverno.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Cluster
+  names:
+    kind: ClusterPolicy
+    plural: clusterpolicies
+    singular: clusterpolicy
+    shortNames:
+    - cpol
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        status: {}
+        spec:
+          required:
+          - rules
+          properties:
+          # default values to be handled by user
+            validationFailureAction:
+              type: string
+              enum: 
+              - enforce # blocks the resorce api-reques if a rule fails.
+              - audit # allows resource creation and reports the failed validation rules as violations. Default
+            background:
+              type: boolean
+            rules:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - match
+                properties:
+                  name:
+                    type: string
+                  match:
+                    type: object
+                    required:
+                    - resources
+                    properties:
+                      roles:
+                        type: array
+                        items:
+                          type: string
+                      clusterRoles:
+                        type: array
+                        items:
+                          type: string
+                      subjects:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - kind
+                          - name
+                          properties:
+                            kind:
+                              type: string
+                            apiGroup:
+                              type: string
+                            name:
+                              type: string
+                            Namespace:
+                              type: string
+                      resources:
+                        type: object
+                        minProperties: 1
+                        properties:
+                          kinds:
+                            type: array
+                            items:
+                              type: string
+                          name:
+                            type: string
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          selector:
+                            properties:
+                              matchLabels:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - key
+                                  - operator
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                  exclude:
+                    type: object
+                    properties:
+                      roles:
+                        type: array
+                        items:
+                          type: string
+                      clusterRoles:
+                        type: array
+                        items:
+                          type: string
+                      subjects:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - kind
+                          - name
+                          properties:
+                            kind:
+                              type: string
+                            apiGroup:
+                              type: string
+                            name:
+                              type: string
+                            Namespace:
+                              type: string
+                      resources:
+                        type: object
+                        properties:
+                          kinds:
+                            type: array
+                            items:
+                              type: string
+                          name:
+                            type: string
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          selector:
+                            properties:
+                              matchLabels:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - key
+                                  - operator
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                  preconditions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - key  # can be of any type
+                      - operator # typed
+                      - value # can be of any type
+                  mutate:
+                    type: object
+                    properties:
+                      overlay:
+                        AnyValue: {}
+                      patches:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - path
+                          - op
+                          properties:
+                            path:
+                              type: string
+                            op:
+                              type: string
+                              enum:
+                              - add
+                              - replace
+                              - remove
+                            value:
+                              AnyValue: {}
+                  validate:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                      pattern:
+                        AnyValue: {}
+                      anyPattern:
+                        AnyValue: {}
+                  generate:
+                    type: object
+                    required:
+                    - kind
+                    - name
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                      clone: 
+                        type: object
+                        required:
+                        - namespace
+                        - name
+                        properties:
+                          namespace:
+                            type: string
+                          name:
+                            type: string
+                      data:
+                        AnyValue: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterpolicyviolations.kyverno.io
+spec:
+  group: kyverno.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Cluster
+  names:
+    kind: ClusterPolicyViolation
+    plural: clusterpolicyviolations
+    singular: clusterpolicyviolation
+    shortNames:
+    - cpolv
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Policy
+    type: string
+    description: The policy that resulted in the violation
+    JSONPath: .spec.policy
+  - name: ResourceKind
+    type: string
+    description: The resource kind that cause the violation
+    JSONPath: .spec.resource.kind
+  - name: ResourceName
+    type: string
+    description: The resource name that caused the violation
+    JSONPath: .spec.resource.name
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+          - policy
+          - resource
+          - rules
+          properties:
+            policy:
+              type: string
+            resource:
+              type: object
+              required:
+              - kind
+              - name
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+            rules:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - type
+                - message
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                  message:
+                    type: string
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: policyviolations.kyverno.io
+spec:
+  group: kyverno.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    kind: PolicyViolation
+    plural: policyviolations
+    singular: policyviolation
+    shortNames:
+    - polv
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Policy
+    type: string
+    description: The policy that resulted in the violation
+    JSONPath: .spec.policy
+  - name: ResourceKind
+    type: string
+    description: The resource kind that cause the violation
+    JSONPath: .spec.resource.kind
+  - name: ResourceName
+    type: string
+    description: The resource name that caused the violation
+    JSONPath: .spec.resource.name
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+          - policy
+          - resource
+          - rules
+          properties:
+            policy:
+              type: string
+            resource:
+              type: object
+              required:
+              - kind
+              - name
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+            rules:
+              type: array
+              items:
+                type: object
+                required:
+                - name
+                - type
+                - message
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                  message:
+                    type: string
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: generaterequests.kyverno.io
+spec:
+  group: kyverno.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    kind: GenerateRequest
+    plural: generaterequests
+    singular: generaterequest
+    shortNames:
+    - gr
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Policy
+    type: string
+    description: The policy that resulted in the violation
+    JSONPath: .spec.policy
+  - name: ResourceKind
+    type: string
+    description: The resource kind that cause the violation
+    JSONPath: .spec.resource.kind
+  - name: ResourceName
+    type: string
+    description: The resource name that caused the violation
+    JSONPath: .spec.resource.name
+  - name: ResourceNamespace
+    type: string
+    description: The resource namespace that caused the violation
+    JSONPath: .spec.resource.namespace
+  - name: status
+    type : string
+    description: Current state of generate request
+    JSONPath: .status.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+          - policy
+          - resource
+          properties:
+            policy:
+              type: string
+            resource:
+              type: object
+              required:
+              - kind 
+              - name
+              properties:
+                kind:
+                  type: string
+                name: 
+                  type: string
+                namespace:
+                  type: string

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Expand the name of the chart. */}}
+{{- define "kyverno.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kyverno.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "kyverno.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Helm required labels */}}
+{{- define "kyverno.labels" -}}
+app.kubernetes.io/name: {{ template "kyverno.name" . }}
+helm.sh/chart: {{ template "kyverno.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/* matchLabels */}}
+{{- define "kyverno.matchLabels" -}}
+app.kubernetes.io/name: {{ template "kyverno.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* Get the config map name. */}}
+{{- define "kyverno.configMapName" -}}
+{{- printf "%s" (default (include "kyverno.fullname" .) .Values.config.existingConfig) -}}
+{{- end -}}
+
+{{/* Create the name of the service to use */}}
+{{- define "kyverno.serviceName" -}}
+{{- printf "%s-svc" (include "kyverno.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.serviceAccountName" -}}
+{{- if .Values.rbac.serviceAccount.create -}}
+    {{ default (include "kyverno.fullname" .) .Values.rbac.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.rbac.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/clusterrole.yaml
+++ b/charts/kyverno/templates/clusterrole.yaml
@@ -1,0 +1,147 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "kyverno.fullname" . }}:policyviolations
+rules:
+- apiGroups: ["kyverno.io"]
+  resources:
+  - policyviolations
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kyverno.fullname" . }}:webhook
+rules:
+# Dynamic creation of webhooks, events & certs
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  verbs:
+  - create
+  - delete
+  - get 
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  - certificatesigningrequests/status
+  resourceNames:
+    - kubernetes.io/legacy-unknown
+  verbs:
+  - create
+  - delete
+  - get 
+  - update
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  resourceNames:
+  - kubernetes.io/legacy-unknown
+  verbs:
+  - approve 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kyverno.fullname" . }}:userinfo
+rules:
+# get the roleRef for incoming api-request user
+- apiGroups:
+  - "*"
+  resources:
+  - rolebindings
+  - clusterrolebindings
+  - configmaps
+  verbs:
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kyverno.fullname" . }}:customresources
+rules:
+# Kyverno CRs
+- apiGroups:
+  - '*'
+  resources:
+  - clusterpolicies
+  - clusterpolicies/status
+  - clusterpolicyviolations
+  - clusterpolicyviolations/status
+  - policyviolations
+  - policyviolations/status
+  - generaterequests
+  - generaterequests/status
+  verbs:
+  - create
+  - delete
+  - get 
+  - list 
+  - patch
+  - update
+  - watch
+---  
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kyverno.fullname" . }}:policycontroller
+rules:
+# background processing, identify all existing resources
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kyverno.fullname" . }}:generatecontroller
+rules:
+# process generate rules to generate resources
+- apiGroups:
+  - "*"
+  resources:
+  - namespaces
+  - networkpolicies
+  - secrets
+  - configmaps
+  - resourcequotas
+  - limitranges
+  - clusterroles
+  - rolebindings
+  - clusterrolebindings
+  {{- range .Values.generatecontrollerExtraResources }}
+  - {{ . }}
+  {{- end }}
+  verbs:
+  - create
+  - update
+  - delete
+  - get
+# dynamic watches on trigger resources for generate rules
+# re-evaluate the policy if the resource is updated
+- apiGroups:
+  - '*'
+  resources:
+  - namespaces
+  verbs:
+  - watch
+{{- end }}

--- a/charts/kyverno/templates/clusterrolebinding.yaml
+++ b/charts/kyverno/templates/clusterrolebinding.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "kyverno.fullname" . }}:webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kyverno.fullname" . }}:webhook
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kyverno.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "kyverno.fullname" . }}:userinfo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kyverno.fullname" . }}:userinfo
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kyverno.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "kyverno.fullname" . }}:customresources
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kyverno.fullname" . }}:customresources
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kyverno.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "kyverno.fullname" . }}:policycontroller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kyverno.fullname" . }}:policycontroller
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kyverno.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---  
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "kyverno.fullname" . }}:generatecontroller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kyverno.fullname" . }}:generatecontroller
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kyverno.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/kyverno/templates/configmap.yaml
+++ b/charts/kyverno/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if (not .Values.config.existingConfig) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels: {{ include "kyverno.labels" . | nindent 4 }}
+  name: {{ template "kyverno.configMapName" . }}
+data:
+  # resource types to be skipped by kyverno policy engine
+  resourceFilters: {{ join "" .Values.config.resourceFilters | quote }}
+{{- end -}}

--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "kyverno.fullname" . }}
+  labels: {{ include "kyverno.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{ include "kyverno.matchLabels" . | nindent 6 }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels: {{ include "kyverno.labels" . | nindent 8 }}
+        {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "kyverno.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      initContainers:
+        - name: kyverno-pre
+          image: {{ .Values.initImage.repository }}:{{ default .Chart.AppVersion (default .Values.image.tag .Values.initImage.tag) }}
+          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.initImage.pullPolicy }}
+      containers:
+        - name: kyverno
+          image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraArgs }}
+          args: {{ tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources: {{ tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+          - containerPort: 443
+            name: https
+            protocol: TCP
+          env:
+          - name: INIT_CONFIG
+            value: {{ template "kyverno.configMapName" . }}
+        {{- with .Values.livenessProbe }}
+          livenessProbe: {{ tpl (toYaml .) $ | nindent 12 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
+          readinessProbe: {{ tpl (toYaml .) $ | nindent 12 }}
+        {{- end }}

--- a/charts/kyverno/templates/secret.yaml
+++ b/charts/kyverno/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.createSelfSignedCert }}
+{{- $ca := .ca | default (genCA (printf "*.%s.svc" .Release.Namespace) 1024) -}}
+{{- $cert := genSignedCert (printf "%s.%s.svc" (include "kyverno.serviceName" .) .Release.Namespace) nil nil 1024 $ca -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kyverno.serviceName" . }}.{{ .Release.Namespace }}.svc.kyverno-tls-ca
+  labels: {{ include "kyverno.labels" . | nindent 4 }}
+data:
+  rootCA.crt: {{ $ca.Cert | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kyverno.serviceName" . }}.{{ .Release.Namespace }}.svc.kyverno-tls-pair
+  labels: {{ include "kyverno.labels" . | nindent 4 }}
+  annotations:
+    self-signed-cert: "true"
+type: kubernetes.io/tls
+data:
+  tls.key: {{ $cert.Key | b64enc }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+{{- end -}}

--- a/charts/kyverno/templates/service.yaml
+++ b/charts/kyverno/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kyverno.serviceName" . }}
+  labels: {{ include "kyverno.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: https
+    protocol: TCP
+    name: https
+    {{- if and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+  selector: {{ include "kyverno.matchLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}

--- a/charts/kyverno/templates/serviceaccount.yaml
+++ b/charts/kyverno/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kyverno.serviceAccountName" . }}
+  labels: {{ include "kyverno.labels" . | nindent 4 }}
+  {{- if .Values.rbac.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.rbac.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -1,0 +1,126 @@
+nameOverride:
+fullnameOverride:
+
+rbac:
+  create: true
+  serviceAccount:
+    create: true
+    name:
+    annotations: {}
+    #   example.com/annotation: value
+
+image:
+  repository: nirmata/kyverno
+  # Defaults to appVersion in Chart.yaml if omitted
+  tag:
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+  # - secretName
+initImage:
+  repository: nirmata/kyvernopre
+  # If initImage.tag is missing, defaults to image.tag
+  tag:
+  # If initImage.pullPolicy is missing, defaults to image.pullPolicy
+  pullPolicy:
+  # No pull secrets just for initImage; just add to image.pullSecrets
+
+replicaCount: 1
+
+podLabels: {}
+#   example.com/label: foo
+
+podAnnotations: {}
+#   example.com/annotation: foo
+
+podSecurityContext: {}
+
+affinity: {}
+nodeSelector: {}
+tolerations: []
+
+extraArgs: []
+# - --fqdn-as-cn
+# - --webhooktimeout=4
+
+resources:
+#   limits:
+#     cpu: 1000m
+#     memory: 500Mi
+#   requests:
+#     cpu: 100m
+#     memory: 100Mi
+
+## Liveness Probe. The block is directly forwarded into the deployment, so you can use whatever livenessProbe configuration you want.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+##
+livenessProbe:
+#   httpGet:
+#     path: /healthz
+#     port: https
+#     scheme: HTTPS
+#   initialDelaySeconds: 10
+#   periodSeconds: 10
+#   timeoutSeconds: 5
+#   failureThreshold: 2
+#   successThreshold: 1
+
+## Readiness Probe. The block is directly forwarded into the deployment, so you can use whatever readinessProbe configuration you want.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+##
+readinessProbe:
+#   httpGet:
+#     path: /healthz
+#     port: https
+#     scheme: HTTPS
+#   initialDelaySeconds: 5
+#   periodSeconds: 10
+#   timeoutSeconds: 5
+#   failureThreshold: 6
+#   successThreshold: 1
+
+# TODO(mbarrien): Should we just list all resources for the
+# generatecontroller in here rather than having defaults hard-coded?
+generatecontrollerExtraResources:
+# - ResourceA
+# - ResourceB
+
+config:
+  # resource types to be skipped by kyverno policy engine
+  # Make sure to surround each entry in quotes so that it doesn't get parsed
+  # as a nested YAML list. These are joined together without spaces in the configmap
+  resourceFilters:
+  - "[Event,*,*]"
+  - "[*,kube-system,*]"
+  - "[*,kube-public,*]"
+  - "[*,kube-node-lease,*]"
+  - "[Node,*,*]"
+  - "[APIService,*,*]"
+  - "[TokenReview,*,*]"
+  - "[SubjectAccessReview,*,*]"
+  - "[*,kyverno,*]"
+  # Or give the name of an existing config map (ignores default/provided resourceFilters)
+  existingConfig:
+  # existingConfig: init-config
+
+service:
+  port: 443
+  type: ClusterIP
+  # Only used if service.type is NodePort
+  nodePort:
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+
+# Kyverno requires a certificate key pair and corresponding certificate authority
+# to properly register its webhooks. This can be done in one of 3 ways:
+# 1) Use kube-controller-manager to generate a CA-signed certificate (preferred)
+# 2) Provide your own CA and cert.
+#    In this case, you will need to create a certificate with a specific name and data structure.
+#    As long as you follow the naming scheme, it will be automatically picked up.
+#    kyverno-svc.(namespace).svc.kyverno-tls-ca (with data entry named rootCA.crt)
+#    kyverno-svc.kyverno.svc.kyverno-tls-key-pair (with data entries named tls.key and tls.crt)
+# 3) Let Helm generate a self signed cert, by setting createSelfSignedCert true
+# If letting Kyverno create its own CA or providing your own, make createSelfSignedCert is false
+createSelfSignedCert: false


### PR DESCRIPTION
Adds a Helm chart for Kyverno, as a way to install it instead of https://github.com/nirmata/kyverno/blob/master/definitions/install.yaml. Closes #835.

It is written in a manner that allows it to be installed in different namespaces or with a different name, but because of Kyverno's code hard-coding assumptions about names, it MUST be installed in the Kyverno namespace and MUST be installed with the release name "kyverno"; you will not get a working installation if you use different names.

The chart supports providing generatecontroller resources to add to a default list, and supports creating a self signed cert via Helm.

Other things to point out (that can be reversed if so desired):
* For the resourceFilters, we deconstruct it into a yaml list, one entry for each filter. For adding to the configmap, we just join them back together.
* Following standard Helm chart practices, we make the RBAC optional, allowing the user to potentially create their own ClusterRoles, ClusterRoleBindings, and ServiceAccount.
* Added a name to port 443, "https", and referred to the port by name in the service.
* Added placeholders for liveness and readiness probes and resource limits; they default to empty.
* Added support for annotations and labels, in case the user's cluster has org specific naming schemes.
* Added support for tolerations, node affinity, node selector, and security contexts not originally present in the source yaml
* Intentionally does not assume a configmap called init-config, instead opting for the naming convention of matching the full release name. If the user already has their own init-config, they can override in the values passed to Helm.

Note that this PR does not address where a chart would be hosted; in theory the chart should be packaged up and hosted in an actual Helm repo and where you want to host it is outside of my scope as an outside contributor right now. There is the Helm stable charts repo, but they have deprecated taking in new charts, instead moving to a distributed model where each org self hosts their own charts. I wrote the README.md to assume local installation from the charts directory.