### PR TITLE
fix policy violation updated without owner

### DIFF
--- a/pkg/policy/apply.go
+++ b/pkg/policy/apply.go
@@ -79,7 +79,7 @@ func getFailedOverallRuleInfo(resource unstructured.Unstructured, engineResponse
 
 	// resource does not match so there was a mutation rule violated
 	for index, rule := range engineResponse.PolicyResponse.Rules {
-		log.V(4).Info("veriying if policy rule was applied before", "rule", rule.Name)
+		log.V(4).Info("verifying if policy rule was applied before", "rule", rule.Name)
 
 		patches := dropKyvernoAnnotation(rule.Patches, log)
 		if len(patches) == 0 {

--- a/pkg/policy/apply.go
+++ b/pkg/policy/apply.go
@@ -32,7 +32,7 @@ func applyPolicy(policy kyverno.ClusterPolicy, resource unstructured.Unstructure
 	}()
 
 	var engineResponses []response.EngineResponse
-	var engineResponse response.EngineResponse
+	var engineResponseMutation, engineResponseValidation response.EngineResponse
 	var err error
 	// build context
 	ctx := context.NewContext()
@@ -41,15 +41,14 @@ func applyPolicy(policy kyverno.ClusterPolicy, resource unstructured.Unstructure
 		logger.Error(err, "enable to add transform resource to ctx")
 	}
 	//MUTATION
-	engineResponse, err = mutation(policy, resource, ctx, logger)
-	engineResponses = append(engineResponses, engineResponse)
+	engineResponseMutation, err = mutation(policy, resource, ctx, logger)
 	if err != nil {
 		logger.Error(err, "failed to process mutation rule")
 	}
 
 	//VALIDATION
-	engineResponse = engine.Validate(engine.PolicyContext{Policy: policy, Context: ctx, NewResource: resource})
-	engineResponses = append(engineResponses, engineResponse)
+	engineResponseValidation = engine.Validate(engine.PolicyContext{Policy: policy, Context: ctx, NewResource: resource})
+	engineResponses = append(engineResponses, mergeRuleRespose(engineResponseMutation, engineResponseValidation))
 
 	//TODO: GENERATION
 	return engineResponses
@@ -81,27 +80,31 @@ func getFailedOverallRuleInfo(resource unstructured.Unstructured, engineResponse
 	// resource does not match so there was a mutation rule violated
 	for index, rule := range engineResponse.PolicyResponse.Rules {
 		log.V(4).Info("veriying if policy rule was applied before", "rule", rule.Name)
-		if len(rule.Patches) == 0 {
+
+		patches := dropKyvernoAnnotation(rule.Patches, log)
+		if len(patches) == 0 {
 			continue
 		}
-		patch, err := jsonpatch.DecodePatch(utils.JoinPatches(rule.Patches))
+
+		patch, err := jsonpatch.DecodePatch(utils.JoinPatches(patches))
 		if err != nil {
-			log.Error(err, "failed to decode JSON patch", "patches", rule.Patches)
+			log.Error(err, "failed to decode JSON patch", "patches", patches)
 			return response.EngineResponse{}, err
 		}
 
 		// apply the patches returned by mutate to the original resource
 		patchedResource, err := patch.Apply(rawResource)
 		if err != nil {
-			log.Error(err, "failed to apply JSON patch", "patches", rule.Patches)
+			log.Error(err, "failed to apply JSON patch", "patches", patches)
 			return response.EngineResponse{}, err
 		}
 		if !jsonpatch.Equal(patchedResource, rawResource) {
 			log.V(4).Info("policy rule conditions not satisfied by resource", "rule", rule.Name)
 			engineResponse.PolicyResponse.Rules[index].Success = false
-			engineResponse.PolicyResponse.Rules[index].Message = fmt.Sprintf("mutation json patches not found at resource path %s", extractPatchPath(rule.Patches, log))
+			engineResponse.PolicyResponse.Rules[index].Message = fmt.Sprintf("mutation json patches not found at resource path %s", extractPatchPath(patches, log))
 		}
 	}
+
 	return engineResponse, nil
 }
 
@@ -124,4 +127,27 @@ func extractPatchPath(patches [][]byte, log logr.Logger) string {
 		resultPath = append(resultPath, data.Path)
 	}
 	return strings.Join(resultPath, ";")
+}
+
+func dropKyvernoAnnotation(patches [][]byte, log logr.Logger) (resultPathes [][]byte) {
+	for _, patch := range patches {
+		var data jsonPatch
+		if err := json.Unmarshal(patch, &data); err != nil {
+			log.Error(err, "failed to decode the generate patch", "patch", string(patch))
+			continue
+		}
+
+		value := fmt.Sprintf("%v", data.Value)
+		if strings.Contains(value, engine.PodTemplateAnnotation) {
+			continue
+		}
+
+		resultPathes = append(resultPathes, patch)
+	}
+	return
+}
+
+func mergeRuleRespose(mutation, validation response.EngineResponse) response.EngineResponse {
+	mutation.PolicyResponse.Rules = append(mutation.PolicyResponse.Rules, validation.PolicyResponse.Rules...)
+	return mutation
 }

--- a/pkg/policy/existing.go
+++ b/pkg/policy/existing.go
@@ -167,6 +167,10 @@ func getResourcesPerNamespace(kind string, client *client.Client, namespace stri
 	}
 	// filter based on name
 	for _, r := range list.Items {
+		if r.GetDeletionTimestamp() != nil {
+			continue
+		}
+
 		// match name
 		if rule.MatchResources.Name != "" {
 			if !wildcard.Match(rule.MatchResources.Name, r.GetName()) {

--- a/pkg/policyviolation/clusterpv.go
+++ b/pkg/policyviolation/clusterpv.go
@@ -93,8 +93,17 @@ func (cpv *clusterPV) createPV(newPv *kyverno.ClusterPolicyViolation) error {
 	if err != nil {
 		return fmt.Errorf("failed to retry getting resource for policy violation %s/%s: %v", newPv.Name, newPv.Spec.Policy, err)
 	}
+
+	if obj.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
 	// set owner reference to resource
-	ownerRef := createOwnerReference(obj)
+	ownerRef, ok := createOwnerReference(obj)
+	if !ok {
+		return nil
+	}
+
 	newPv.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
 
 	// create resource

--- a/pkg/policyviolation/clusterpv.go
+++ b/pkg/policyviolation/clusterpv.go
@@ -132,13 +132,14 @@ func (cpv *clusterPV) updatePV(newPv, oldPv *kyverno.ClusterPolicyViolation) err
 	// set name
 	newPv.SetName(oldPv.Name)
 	newPv.SetResourceVersion(oldPv.ResourceVersion)
+	newPv.SetOwnerReferences(oldPv.GetOwnerReferences())
 
 	// update resource
 	_, err = cpv.kyvernoInterface.ClusterPolicyViolations().Update(newPv)
 	if err != nil {
 		return fmt.Errorf("failed to update cluster policy violation: %v", err)
 	}
-	logger.Info("cluster policy violation created")
+	logger.Info("cluster policy violation updated")
 
 	if newPv.Annotations["fromSync"] != "true" {
 		cpv.policyStatusListener.Send(violationCount{policyName: newPv.Spec.Policy, violatedRules: newPv.Spec.ViolatedRules})

--- a/pkg/policyviolation/common.go
+++ b/pkg/policyviolation/common.go
@@ -14,9 +14,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func createOwnerReference(resource *unstructured.Unstructured) metav1.OwnerReference {
+func createOwnerReference(resource *unstructured.Unstructured) (metav1.OwnerReference, bool) {
 	controllerFlag := true
 	blockOwnerDeletionFlag := true
+
+	apiversion := resource.GetAPIVersion()
+	kind := resource.GetKind()
+	name := resource.GetName()
+	uid := resource.GetUID()
+
+	if apiversion == "" || kind == "" || name == "" || uid == "" {
+		return metav1.OwnerReference{}, false
+	}
+
 	ownerRef := metav1.OwnerReference{
 		APIVersion:         resource.GetAPIVersion(),
 		Kind:               resource.GetKind(),
@@ -25,7 +35,7 @@ func createOwnerReference(resource *unstructured.Unstructured) metav1.OwnerRefer
 		Controller:         &controllerFlag,
 		BlockOwnerDeletion: &blockOwnerDeletionFlag,
 	}
-	return ownerRef
+	return ownerRef, true
 }
 
 func retryGetResource(client *client.Client, rspec kyverno.ResourceSpec) (*unstructured.Unstructured, error) {

--- a/pkg/policyviolation/namespacedpv.go
+++ b/pkg/policyviolation/namespacedpv.go
@@ -11,6 +11,7 @@ import (
 	client "github.com/nirmata/kyverno/pkg/dclient"
 	"github.com/nirmata/kyverno/pkg/policystatus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	unstructedv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 //NamespacedPV ...
@@ -97,6 +98,12 @@ func (nspv *namespacedPV) createPV(newPv *kyverno.PolicyViolation) error {
 		return nil
 	}
 
+	if newPv.Spec.ResourceSpec.Kind == "Pod" {
+		if isEvictedPod(obj.Object) {
+			return nil
+		}
+	}
+
 	// set owner reference to resource
 	ownerRef, ok := createOwnerReference(obj)
 	if !ok {
@@ -141,4 +148,13 @@ func (nspv *namespacedPV) updatePV(newPv, oldPv *kyverno.PolicyViolation) error 
 	}
 	logger.Info("namespaced policy violation created")
 	return nil
+}
+
+func isEvictedPod(pod map[string]interface{}) bool {
+	reason, ok, _ := unstructedv1.NestedString(pod, "status", "reason")
+	if !ok {
+		return false
+	}
+
+	return reason == "Evicted"
 }

--- a/pkg/policyviolation/namespacedpv.go
+++ b/pkg/policyviolation/namespacedpv.go
@@ -137,6 +137,7 @@ func (nspv *namespacedPV) updatePV(newPv, oldPv *kyverno.PolicyViolation) error 
 	// set name
 	newPv.SetName(oldPv.Name)
 	newPv.SetResourceVersion(oldPv.ResourceVersion)
+	newPv.SetOwnerReferences(oldPv.GetOwnerReferences())
 	// update resource
 	_, err = nspv.kyvernoInterface.PolicyViolations(newPv.GetNamespace()).Update(newPv)
 	if err != nil {
@@ -146,7 +147,7 @@ func (nspv *namespacedPV) updatePV(newPv, oldPv *kyverno.PolicyViolation) error 
 	if newPv.Annotations["fromSync"] != "true" {
 		nspv.policyStatusListener.Send(violationCount{policyName: newPv.Spec.Policy, violatedRules: newPv.Spec.ViolatedRules})
 	}
-	logger.Info("namespaced policy violation created")
+	logger.Info("namespaced policy violation updated")
 	return nil
 }
 

--- a/pkg/policyviolation/namespacedpv.go
+++ b/pkg/policyviolation/namespacedpv.go
@@ -92,8 +92,17 @@ func (nspv *namespacedPV) createPV(newPv *kyverno.PolicyViolation) error {
 	if err != nil {
 		return fmt.Errorf("failed to retry getting resource for policy violation %s/%s: %v", newPv.Name, newPv.Spec.Policy, err)
 	}
+
+	if obj.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
 	// set owner reference to resource
-	ownerRef := createOwnerReference(obj)
+	ownerRef, ok := createOwnerReference(obj)
+	if !ok {
+		return nil
+	}
+
 	newPv.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
 
 	// create resource


### PR DESCRIPTION
Fixes #695 , a few other fixes:
- skip generating pv on the evicted pod
- fix violations get re-created on the same resource
- skip background processing if a resource is to be deleted
