### PR TITLE
removing hardcoded namespace from the code

### DIFF
--- a/charts/kyverno/templates/configmap.yaml
+++ b/charts/kyverno/templates/configmap.yaml
@@ -4,6 +4,7 @@ kind: ConfigMap
 metadata:
   labels: {{ include "kyverno.labels" . | nindent 4 }}
   name: {{ template "kyverno.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
 data:
   # resource types to be skipped by kyverno policy engine
   resourceFilters: {{ join "" .Values.config.resourceFilters | quote }}

--- a/charts/kyverno/templates/deployment.yaml
+++ b/charts/kyverno/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "kyverno.fullname" . }}
   labels: {{ include "kyverno.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels: {{ include "kyverno.matchLabels" . | nindent 6 }}
@@ -57,6 +58,10 @@ spec:
           env:
           - name: INIT_CONFIG
             value: {{ template "kyverno.configMapName" . }}
+          - name: KYVERNO_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         {{- with .Values.livenessProbe }}
           livenessProbe: {{ tpl (toYaml .) $ | nindent 12 }}
         {{- end }}

--- a/charts/kyverno/templates/service.yaml
+++ b/charts/kyverno/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{ template "kyverno.serviceName" . }}
   labels: {{ include "kyverno.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.service.annotations }}
   annotations: {{ tpl (toYaml .) $ | nindent 4 }}
   {{- end }}

--- a/charts/kyverno/templates/serviceaccount.yaml
+++ b/charts/kyverno/templates/serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
   {{- if .Values.rbac.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.rbac.serviceAccount.annotations | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -762,6 +762,10 @@ spec:
         env:
         - name: INIT_CONFIG
           value: init-config
+        - name: KYVERNO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: nirmata/kyverno:v1.1.6
         imagePullPolicy: Always
         livenessProbe:

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -226,7 +226,8 @@ To run controller in this mode you should prepare a TLS key/certificate pair for
 
 1. Run `sudo scripts/deploy-controller-debug.sh --service=localhost --serverIP=<server_IP>`, where <server_IP> is the IP address of the host where controller runs. This scripts will generate a TLS certificate for debug webhook server and register this webhook in the cluster. It also registers a CustomResource policy.
 
-2. Start the controller using the following command: `sudo go run ./cmd/kyverno/main.go --kubeconfig=~/.kube/config --serverIP=<server_IP>`
+2. Start the controller using the following command: `sudo KYVERNO_NAMESPACE=kyverno go run ./cmd/kyverno/main.go --kubeconfig=~/.kube/config --serverIP=<server_IP>`
+
 
 # Filter Kubernetes resources that admission webhook should not process
 The admission webhook checks if a policy is applicable on all admission requests. The Kubernetes kinds that are not be processed can be filtered by adding a `ConfigMap` in namespace `kyverno` and specifying the resources to be filtered under `data.resourceFilters`. The default name of this `ConfigMap` is `init-config` but can be changed by modifying the value of the environment variable `INIT_CONFIG` in the kyverno deployment dpec. `data.resourceFilters` must be a sequence of one or more `[<Kind>,<Namespace>,<Name>]` entries with `*` as wildcard. Thus, an item `[Node,*,*]` means that admissions of `Node` in any namespace and with any name will be ignored.

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -19,8 +19,6 @@ helm install kyverno --namespace kyverno kyverno/kyverno
 
 ```
 
-Note: the namespace must be `kyverno`. See issue #841.
-
 ## Install Kyverno using YAMLs
 
 The Kyverno policy engine runs as an admission webhook and requires a CA-signed certificate and key to setup secure TLS communication with the kube-apiserver (the CA can be self-signed). 

--- a/pkg/checker/status.go
+++ b/pkg/checker/status.go
@@ -5,12 +5,13 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
+	"github.com/nirmata/kyverno/pkg/config"
 	dclient "github.com/nirmata/kyverno/pkg/dclient"
 	"github.com/nirmata/kyverno/pkg/event"
 )
 
-const deployName string = "kyverno"
-const deployNamespace string = "kyverno"
+var deployName string = config.KubePolicyDeploymentName
+var deployNamespace string = config.KubePolicyNamespace
 
 const annCounter string = "kyverno.io/generationCounter"
 const annWebhookStatus string = "kyverno.io/webhookActive"
@@ -96,8 +97,8 @@ func (vc StatusControl) setStatus(status string) error {
 func createStatusUpdateEvent(status string, eventGen event.Interface) {
 	e := event.Info{}
 	e.Kind = "Deployment"
-	e.Namespace = "kyverno"
-	e.Name = "kyverno"
+	e.Namespace = deployNamespace
+	e.Name = deployName
 	e.Reason = "Update"
 	e.Message = fmt.Sprintf("admission control webhook active status changed to %s", status)
 	eventGen.Add(e)
@@ -110,7 +111,7 @@ func (vc StatusControl) IncrementAnnotation() error {
 	var err error
 	deploy, err := vc.client.GetResource("Deployment", deployNamespace, deployName)
 	if err != nil {
-		logger.Error(err, "failed to find Kyverno", "deploymeny", deployName, "namespace", deployNamespace)
+		logger.Error(err, "failed to find Kyverno", "deployment", deployName, "namespace", deployNamespace)
 		return err
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+
 	"github.com/go-logr/logr"
 	rest "k8s.io/client-go/rest"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
@@ -9,8 +11,6 @@ import (
 // These constants MUST be equal to the corresponding names in service definition in definitions/install.yaml
 
 const (
-	//KubePolicyNamespace default kyverno namespace
-	KubePolicyNamespace = "kyverno"
 	//WebhookServiceName default kyverno webhook service name
 	WebhookServiceName = "kyverno-svc"
 
@@ -60,6 +60,8 @@ const (
 )
 
 var (
+	//KubePolicyNamespace default kyverno namespace
+	KubePolicyNamespace = getKubePolicyNameSpace()
 	//MutatingWebhookServicePath is the path for mutation webhook
 	MutatingWebhookServicePath = "/mutate"
 	//ValidatingWebhookServicePath is the path for validation webhook
@@ -72,7 +74,7 @@ var (
 	VerifyMutatingWebhookServicePath = "/verifymutate"
 	// LivenessServicePath is the path for check liveness health
 	LivenessServicePath = "/health/liveness"
-	// ReadinessServicePath is the path for check readness health 
+	// ReadinessServicePath is the path for check readness health
 	ReadinessServicePath = "/health/readiness"
 )
 
@@ -85,4 +87,13 @@ func CreateClientConfig(kubeconfig string, log logr.Logger) (*rest.Config, error
 	}
 	logger.V(4).Info("Using specified kubeconfig", "kubeconfig", kubeconfig)
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}
+
+// getKubePolicyNameSpace - setting default KubePolicyNameSpace
+func getKubePolicyNameSpace() string {
+	KubePolicyNamespace := os.Getenv("KYVERNO_NAMESPACE")
+	if KubePolicyNamespace == "" {
+		KubePolicyNamespace = "kyverno"
+	}
+	return KubePolicyNamespace
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,6 @@ import (
 )
 
 // These constants MUST be equal to the corresponding names in service definition in definitions/install.yaml
-
 const (
 	//WebhookServiceName default kyverno webhook service name
 	WebhookServiceName = "kyverno-svc"
@@ -55,13 +54,14 @@ const (
 
 	// DeploymentAPIVersion define the default deployment resource apiVersion
 	DeploymentAPIVersion = "extensions/v1beta1"
-	// KubePolicyDeploymentName define the default deployment namespace
-	KubePolicyDeploymentName = "kyverno"
 )
 
 var (
-	//KubePolicyNamespace default kyverno namespace
-	KubePolicyNamespace = getKubePolicyNameSpace()
+	//KubePolicyNamespace is the kyverno policy namespace
+	KubePolicyNamespace = getKyvernoNameSpace()
+	// KubePolicyDeploymentName define the default deployment namespace
+	KubePolicyDeploymentName = getKyvernoNameSpace()
+
 	//MutatingWebhookServicePath is the path for mutation webhook
 	MutatingWebhookServicePath = "/mutate"
 	//ValidatingWebhookServicePath is the path for validation webhook
@@ -90,10 +90,10 @@ func CreateClientConfig(kubeconfig string, log logr.Logger) (*rest.Config, error
 }
 
 // getKubePolicyNameSpace - setting default KubePolicyNameSpace
-func getKubePolicyNameSpace() string {
-	KubePolicyNamespace := os.Getenv("KYVERNO_NAMESPACE")
-	if KubePolicyNamespace == "" {
-		KubePolicyNamespace = "kyverno"
+func getKyvernoNameSpace() string {
+	kyvernoNamespace := os.Getenv("KYVERNO_NAMESPACE")
+	if kyvernoNamespace == "" {
+		kyvernoNamespace = "kyverno"
 	}
-	return KubePolicyNamespace
+	return kyvernoNamespace
 }

--- a/pkg/dclient/client_test.go
+++ b/pkg/dclient/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/nirmata/kyverno/pkg/config"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,7 +39,7 @@ func newFixture(t *testing.T) *fixture {
 		newUnstructured("group/version", "TheKind", "ns-foo", "name-bar"),
 		newUnstructured("group/version", "TheKind", "ns-foo", "name-baz"),
 		newUnstructured("group2/version", "TheKind", "ns-foo", "name2-baz"),
-		newUnstructured("apps/v1", "Deployment", "kyverno", "kyverno"),
+		newUnstructured("apps/v1", "Deployment", config.KubePolicyNamespace, config.KubePolicyDeploymentName),
 	}
 	scheme := runtime.NewScheme()
 	// Create mock client

--- a/pkg/generate/cleanup/controller.go
+++ b/pkg/generate/cleanup/controller.go
@@ -8,6 +8,7 @@ import (
 	kyvernoclient "github.com/nirmata/kyverno/pkg/client/clientset/versioned"
 	kyvernoinformer "github.com/nirmata/kyverno/pkg/client/informers/externalversions/kyverno/v1"
 	kyvernolister "github.com/nirmata/kyverno/pkg/client/listers/kyverno/v1"
+	"github.com/nirmata/kyverno/pkg/config"
 	"github.com/nirmata/kyverno/pkg/constant"
 	dclient "github.com/nirmata/kyverno/pkg/dclient"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -78,7 +79,7 @@ func NewController(
 	c.syncHandler = c.syncGenerateRequest
 
 	c.pLister = pInformer.Lister()
-	c.grLister = grInformer.Lister().GenerateRequests("kyverno")
+	c.grLister = grInformer.Lister().GenerateRequests(config.KubePolicyNamespace)
 
 	c.pSynced = pInformer.Informer().HasSynced
 	c.grSynced = grInformer.Informer().HasSynced

--- a/pkg/generate/cleanup/resource.go
+++ b/pkg/generate/cleanup/resource.go
@@ -2,6 +2,7 @@ package cleanup
 
 import (
 	kyvernoclient "github.com/nirmata/kyverno/pkg/client/clientset/versioned"
+	"github.com/nirmata/kyverno/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -17,5 +18,5 @@ type Control struct {
 
 //Delete deletes the specified resource
 func (c Control) Delete(gr string) error {
-	return c.client.KyvernoV1().GenerateRequests("kyverno").Delete(gr, &metav1.DeleteOptions{})
+	return c.client.KyvernoV1().GenerateRequests(config.KubePolicyNamespace).Delete(gr, &metav1.DeleteOptions{})
 }

--- a/pkg/generate/controller.go
+++ b/pkg/generate/controller.go
@@ -8,6 +8,7 @@ import (
 	kyvernoclient "github.com/nirmata/kyverno/pkg/client/clientset/versioned"
 	kyvernoinformer "github.com/nirmata/kyverno/pkg/client/informers/externalversions/kyverno/v1"
 	kyvernolister "github.com/nirmata/kyverno/pkg/client/listers/kyverno/v1"
+	"github.com/nirmata/kyverno/pkg/config"
 	"github.com/nirmata/kyverno/pkg/constant"
 	dclient "github.com/nirmata/kyverno/pkg/dclient"
 	"github.com/nirmata/kyverno/pkg/event"
@@ -103,7 +104,7 @@ func NewController(
 	c.syncHandler = c.syncGenerateRequest
 
 	c.pLister = pInformer.Lister()
-	c.grLister = grInformer.Lister().GenerateRequests("kyverno")
+	c.grLister = grInformer.Lister().GenerateRequests(config.KubePolicyNamespace)
 
 	c.pSynced = pInformer.Informer().HasSynced
 	c.grSynced = pInformer.Informer().HasSynced

--- a/pkg/generate/status.go
+++ b/pkg/generate/status.go
@@ -3,6 +3,7 @@ package generate
 import (
 	kyverno "github.com/nirmata/kyverno/pkg/api/kyverno/v1"
 	kyvernoclient "github.com/nirmata/kyverno/pkg/client/clientset/versioned"
+	"github.com/nirmata/kyverno/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -23,7 +24,7 @@ func (sc StatusControl) Failed(gr kyverno.GenerateRequest, message string, genRe
 	gr.Status.Message = message
 	// Update Generated Resources
 	gr.Status.GeneratedResources = genResources
-	_, err := sc.client.KyvernoV1().GenerateRequests("kyverno").UpdateStatus(&gr)
+	_, err := sc.client.KyvernoV1().GenerateRequests(config.KubePolicyNamespace).UpdateStatus(&gr)
 	if err != nil {
 		log.Log.Error(err, "failed to update generate request status", "name", gr.Name)
 		return err
@@ -39,7 +40,7 @@ func (sc StatusControl) Success(gr kyverno.GenerateRequest, genResources []kyver
 	// Update Generated Resources
 	gr.Status.GeneratedResources = genResources
 
-	_, err := sc.client.KyvernoV1().GenerateRequests("kyverno").UpdateStatus(&gr)
+	_, err := sc.client.KyvernoV1().GenerateRequests(config.KubePolicyNamespace).UpdateStatus(&gr)
 	if err != nil {
 		log.Log.Error(err, "failed to update generate request status", "name", gr.Name)
 		return err


### PR DESCRIPTION
## Related issue


Closes #841 

**What type of PR is this?**
> /kind bug


## Proposed changes

Currently `KubePolicyNamespace` is hardcode in the code. Now we are getting it from the environment variable.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](documentation/).

