### PR TITLE
added support for namespaced cluster policy

### DIFF
--- a/charts/kyverno/crds/crds.yaml
+++ b/charts/kyverno/crds/crds.yaml
@@ -10,7 +10,7 @@ spec:
     shortNames:
     - cpol
     singular: clusterpolicy
-  scope: Cluster
+  scope: Namespaced
   subresources:
     status: {}
   validation:
@@ -291,7 +291,7 @@ spec:
     shortNames:
     - cpolv
     singular: clusterpolicyviolation
-  scope: Cluster
+  scope: Namespaced
   subresources:
     status: {}
   validation:

--- a/definitions/crds/crds.yaml
+++ b/definitions/crds/crds.yaml
@@ -8,7 +8,7 @@ spec:
     - name: v1
       served: true
       storage: true
-  scope: Cluster
+  scope: Namespaced
   names:
     kind: ClusterPolicy
     plural: clusterpolicies
@@ -274,7 +274,7 @@ spec:
     - name: v1
       served: true
       storage: true
-  scope: Cluster
+  scope: Namespaced
   names:
     kind: ClusterPolicyViolation
     plural: clusterpolicyviolations

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -15,7 +15,7 @@ spec:
     shortNames:
     - cpol
     singular: clusterpolicy
-  scope: Cluster
+  scope: Namespaced
   subresources:
     status: {}
   validation:
@@ -296,7 +296,7 @@ spec:
     shortNames:
     - cpolv
     singular: clusterpolicyviolation
-  scope: Cluster
+  scope: Namespaced
   subresources:
     status: {}
   validation:

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -15,7 +15,7 @@ spec:
     shortNames:
     - cpol
     singular: clusterpolicy
-  scope: Cluster
+  scope: Namespaced
   subresources:
     status: {}
   validation:
@@ -296,7 +296,7 @@ spec:
     shortNames:
     - cpolv
     singular: clusterpolicyviolation
-  scope: Cluster
+  scope: Namespaced
   subresources:
     status: {}
   validation:

--- a/pkg/engine/response/response.go
+++ b/pkg/engine/response/response.go
@@ -13,7 +13,6 @@ type EngineResponse struct {
 	PatchedResource unstructured.Unstructured
 	// Policy Response
 	PolicyResponse PolicyResponse
-
 }
 
 //PolicyResponse policy application response

--- a/pkg/engine/validate/validate.go
+++ b/pkg/engine/validate/validate.go
@@ -133,7 +133,7 @@ func validateArray(log logr.Logger, resourceArray, patternArray []interface{}, o
 					return path, err
 				}
 			}
-		}else{
+		} else {
 			return "", fmt.Errorf("Validate Array failed, array length mismatch, resource Array len is %d and pattern Array len is %d", len(resourceArray), len(patternArray))
 		}
 	}

--- a/pkg/openapi/validation.go
+++ b/pkg/openapi/validation.go
@@ -128,7 +128,7 @@ func (o *Controller) ValidatePolicyMutation(policy v1.ClusterPolicy) error {
 		newPolicy := *policy.DeepCopy()
 		newPolicy.Spec.Rules = rules
 		resource, _ := o.generateEmptyResource(o.definitions[o.kindToDefinitionName[kind]]).(map[string]interface{})
-		if resource == nil  || len(resource) == 0 {
+		if resource == nil || len(resource) == 0 {
 			log.Log.V(2).Info("unable to validate resource. OpenApi definition not found", "kind", kind)
 			return nil
 		}

--- a/pkg/webhooks/server.go
+++ b/pkg/webhooks/server.go
@@ -583,7 +583,7 @@ func (ws *WebhookServer) excludeKyvernoResources(request *v1beta1.AdmissionReque
 				}
 				if !isAuthorized {
 					// convert RAW to unstructured
-					return fmt.Errorf("Resource is managed by a Kyverno policy and cannot be update manually. You can edit the policy %s to update this resource.",labels["policy.kyverno.io/policy-name"])
+					return fmt.Errorf("Resource is managed by a Kyverno policy and cannot be update manually. You can edit the policy %s to update this resource.", labels["policy.kyverno.io/policy-name"])
 				}
 			}
 		}


### PR DESCRIPTION
## Related issue
[https://github.com/nirmata/kyverno/issues/280](https://github.com/nirmata/kyverno/issues/280)
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyvrno Slack Channel](https://kubernetes.slack.com/).
-->

**What type of PR is this?**
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
-->
/kind feature

## Proposed changes
Added support for Namespaced Cluster Policy
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](documentation/).

## Further comments
By default cluster policy is created in "default" namespace and are applied to to all the namespaces.
With the current changes cluster policy can be created in a Namespace and can only be applied to the resources in that namespace.

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
