### PR TITLE
Replace CRD AnyValue fields with empty dict

### DIFF
--- a/charts/kyverno/crds/crds.yaml
+++ b/charts/kyverno/crds/crds.yaml
@@ -99,8 +99,7 @@ spec:
                         - namespace
                         - name
                         type: object
-                      data:
-                        AnyValue: {}
+                      data: {}
                       kind:
                         type: string
                       name:
@@ -180,10 +179,8 @@ spec:
                     type: object
                   mutate:
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patches:
                         items:
                           properties:
@@ -195,8 +192,7 @@ spec:
                               type: string
                             path:
                               type: string
-                            value:
-                              AnyValue: {}
+                            value: {}
                           required:
                           - path
                           - op
@@ -217,8 +213,7 @@ spec:
                     type: array
                   validate:
                     properties:
-                      anyPattern:
-                        AnyValue: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -248,8 +243,7 @@ spec:
                             type: array
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
+                      pattern: {}
                     type: object
                 required:
                 - name

--- a/definitions/crds/crds.yaml
+++ b/definitions/crds/crds.yaml
@@ -181,10 +181,8 @@ spec:
                   mutate:
                     type: object
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patchesJson6902:
                         type: string
                       patches:
@@ -203,17 +201,14 @@ spec:
                               - add
                               - replace
                               - remove
-                            value:
-                              AnyValue: {}
+                            value: {}
                   validate:
                     type: object
                     properties:
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
-                      anyPattern:
-                        AnyValue: {}
+                      pattern: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -267,8 +262,7 @@ spec:
                             type: string
                           name:
                             type: string
-                      data:
-                        AnyValue: {}
+                      data: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -104,8 +104,7 @@ spec:
                         - namespace
                         - name
                         type: object
-                      data:
-                        AnyValue: {}
+                      data: {}
                       kind:
                         type: string
                       name:
@@ -185,10 +184,8 @@ spec:
                     type: object
                   mutate:
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patches:
                         items:
                           properties:
@@ -200,8 +197,7 @@ spec:
                               type: string
                             path:
                               type: string
-                            value:
-                              AnyValue: {}
+                            value: {}
                           required:
                           - path
                           - op
@@ -222,8 +218,7 @@ spec:
                     type: array
                   validate:
                     properties:
-                      anyPattern:
-                        AnyValue: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -253,8 +248,7 @@ spec:
                             type: array
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
+                      pattern: {}
                     type: object
                 required:
                 - name

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -104,8 +104,7 @@ spec:
                         - namespace
                         - name
                         type: object
-                      data:
-                        AnyValue: {}
+                      data: {}
                       kind:
                         type: string
                       name:
@@ -185,10 +184,8 @@ spec:
                     type: object
                   mutate:
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patches:
                         items:
                           properties:
@@ -200,8 +197,7 @@ spec:
                               type: string
                             path:
                               type: string
-                            value:
-                              AnyValue: {}
+                            value: {}
                           required:
                           - path
                           - op
@@ -222,8 +218,7 @@ spec:
                     type: array
                   validate:
                     properties:
-                      anyPattern:
-                        AnyValue: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -253,8 +248,7 @@ spec:
                             type: array
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
+                      pattern: {}
                     type: object
                 required:
                 - name

--- a/definitions/release/install.yaml
+++ b/definitions/release/install.yaml
@@ -104,8 +104,7 @@ spec:
                         - namespace
                         - name
                         type: object
-                      data:
-                        AnyValue: {}
+                      data: {}
                       kind:
                         type: string
                       name:
@@ -185,10 +184,8 @@ spec:
                     type: object
                   mutate:
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patches:
                         items:
                           properties:
@@ -200,8 +197,7 @@ spec:
                               type: string
                             path:
                               type: string
-                            value:
-                              AnyValue: {}
+                            value: {}
                           required:
                           - path
                           - op
@@ -222,8 +218,7 @@ spec:
                     type: array
                   validate:
                     properties:
-                      anyPattern:
-                        AnyValue: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -253,8 +248,7 @@ spec:
                             type: array
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
+                      pattern: {}
                     type: object
                 required:
                 - name


### PR DESCRIPTION
/kind cleanup

## Proposed changes

When deploying Kyverno using Argo CD, we get a persistent false diff for the ClusterPolicy custom resource definition (the definition itself, not instances of ClusterPolicy), because Kubernetes converts the invalid `AnyValue: {}` property types to just an empty dict `{}`. Since the Kubernetes server makes this change to `{}` unilaterally after applying, when a diffing tool like Argo CD compares it against the YAML manifest, each such instance of AnyValue appears as a diff.

I know that since AnyValue is not part of the official OpenAPI V3 schema, and that when you run `kubectl get crd clusterpolicies.kyverno.io -o yaml` the status message shows Kubernetes complaining about "Required value: must not be empty for specified object fields" for all of these fields. In theory the correct solution would be to somehow provide a full schema, but I know this can be tricky for these data/anyPattern/patches types, but at the minimum, I would like to get Argo CD to believe that there are no changes that need to be applied.

Since these fields are already silently turned into `{}` by Kubernetes, this should have no functionality change on existing code/deployments.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](documentation/).
