### PR TITLE
Replace Policy CRD AnyValue fields with empty dict

### DIFF
--- a/charts/kyverno/crds/crds.yaml
+++ b/charts/kyverno/crds/crds.yaml
@@ -506,8 +506,7 @@ spec:
                         - namespace
                         - name
                         type: object
-                      data:
-                        AnyValue: {}
+                      data: {}
                       kind:
                         type: string
                       name:
@@ -583,10 +582,8 @@ spec:
                     type: object
                   mutate:
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patches:
                         items:
                           properties:
@@ -598,8 +595,7 @@ spec:
                               type: string
                             path:
                               type: string
-                            value:
-                              AnyValue: {}
+                            value: {}
                           required:
                           - path
                           - op
@@ -620,8 +616,7 @@ spec:
                     type: array
                   validate:
                     properties:
-                      anyPattern:
-                        AnyValue: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -651,8 +646,7 @@ spec:
                             type: array
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
+                      pattern: {}
                     type: object
                 required:
                 - name

--- a/definitions/crds/crds.yaml
+++ b/definitions/crds/crds.yaml
@@ -447,10 +447,8 @@ spec:
                   mutate:
                     type: object
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patchesJson6902:
                         type: string
                       patches:
@@ -469,17 +467,14 @@ spec:
                               - add
                               - replace
                               - remove
-                            value:
-                              AnyValue: {}
+                            value: {}
                   validate:
                     type: object
                     properties:
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
-                      anyPattern:
-                        AnyValue: {}
+                      pattern: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -533,8 +528,7 @@ spec:
                             type: string
                           name:
                             type: string
-                      data:
-                        AnyValue: {}
+                      data: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/definitions/install.yaml
+++ b/definitions/install.yaml
@@ -511,8 +511,7 @@ spec:
                         - namespace
                         - name
                         type: object
-                      data:
-                        AnyValue: {}
+                      data: {}
                       kind:
                         type: string
                       name:
@@ -588,10 +587,8 @@ spec:
                     type: object
                   mutate:
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patches:
                         items:
                           properties:
@@ -603,8 +600,7 @@ spec:
                               type: string
                             path:
                               type: string
-                            value:
-                              AnyValue: {}
+                            value: {}
                           required:
                           - path
                           - op
@@ -625,8 +621,7 @@ spec:
                     type: array
                   validate:
                     properties:
-                      anyPattern:
-                        AnyValue: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -656,8 +651,7 @@ spec:
                             type: array
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
+                      pattern: {}
                     type: object
                 required:
                 - name

--- a/definitions/install_debug.yaml
+++ b/definitions/install_debug.yaml
@@ -511,8 +511,7 @@ spec:
                         - namespace
                         - name
                         type: object
-                      data:
-                        AnyValue: {}
+                      data: {}
                       kind:
                         type: string
                       name:
@@ -588,10 +587,8 @@ spec:
                     type: object
                   mutate:
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patches:
                         items:
                           properties:
@@ -603,8 +600,7 @@ spec:
                               type: string
                             path:
                               type: string
-                            value:
-                              AnyValue: {}
+                            value: {}
                           required:
                           - path
                           - op
@@ -625,8 +621,7 @@ spec:
                     type: array
                   validate:
                     properties:
-                      anyPattern:
-                        AnyValue: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -656,8 +651,7 @@ spec:
                             type: array
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
+                      pattern: {}
                     type: object
                 required:
                 - name

--- a/definitions/release/install.yaml
+++ b/definitions/release/install.yaml
@@ -511,8 +511,7 @@ spec:
                         - namespace
                         - name
                         type: object
-                      data:
-                        AnyValue: {}
+                      data: {}
                       kind:
                         type: string
                       name:
@@ -588,10 +587,8 @@ spec:
                     type: object
                   mutate:
                     properties:
-                      overlay:
-                        AnyValue: {}
-                      patchStrategicMerge:
-                        AnyValue: {}
+                      overlay: {}
+                      patchStrategicMerge: {}
                       patches:
                         items:
                           properties:
@@ -603,8 +600,7 @@ spec:
                               type: string
                             path:
                               type: string
-                            value:
-                              AnyValue: {}
+                            value: {}
                           required:
                           - path
                           - op
@@ -625,8 +621,7 @@ spec:
                     type: array
                   validate:
                     properties:
-                      anyPattern:
-                        AnyValue: {}
+                      anyPattern: {}
                       deny:
                         properties:
                           conditions:
@@ -656,8 +651,7 @@ spec:
                             type: array
                       message:
                         type: string
-                      pattern:
-                        AnyValue: {}
+                      pattern: {}
                     type: object
                 required:
                 - name


### PR DESCRIPTION
/kind cleanup

## Proposed change

This implements the same change as #1047, except for the new Policy CRD instead of the ClusterPolicy CRD, which apparently did not get those updates before merging.

When deploying Kyverno using Argo CD, we get a persistent false diff for the Policy custom resource definition (the definition itself, not instances of Policy), because Kubernetes converts the invalid AnyValue: {} property types to just an empty dict {}. Since the Kubernetes server makes this change to {} unilaterally after applying, when a diffing tool like Argo CD compares it against the YAML manifest, each such instance of AnyValue appears as a diff.

I know that since AnyValue is not part of the official OpenAPI V3 schema, and that when you run kubectl get crd policies.kyverno.io -o yaml the status message shows Kubernetes complaining about "Required value: must not be empty for specified object fields" for all of these fields. In theory the correct solution would be to somehow provide a full schema, but I know this can be tricky for these data/anyPattern/patches types, but at the minimum, I would like to get Argo CD to believe that there are no changes that need to be applied.

Since these fields are already silently turned into {} by Kubernetes, this should have no functionality change on existing code/deployments.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](documentation/).