### PR TITLE
added validation for openapi_v3

### DIFF
--- a/pkg/openapi/crdSync.go
+++ b/pkg/openapi/crdSync.go
@@ -158,7 +158,10 @@ func (o *Controller) ParseCRD(crd unstructured.Unstructured) {
 
 	parsedSchema, err := openapi_v2.NewSchema(schema, compiler.NewContext("schema", nil))
 	if err != nil {
-		isOpenV3Error(err, crdName)
+		v3valueFound := isOpenV3Error(err)
+		if v3valueFound == false {
+			log.Log.Error(err, "could not parse crd schema", "name", crdName)
+		}
 	}
 
 	o.crdList = append(o.crdList, crdName)
@@ -166,7 +169,7 @@ func (o *Controller) ParseCRD(crd unstructured.Unstructured) {
 	o.definitions[crdName] = parsedSchema
 }
 
-func isOpenV3Error(err error, crdName string) {
+func isOpenV3Error(err error) bool {
 	unsupportedValues := []string{"anyOf", "allOf", "not"}
 	v3valueFound := false
 	for _, value := range unsupportedValues {
@@ -175,10 +178,7 @@ func isOpenV3Error(err error, crdName string) {
 			break
 		}
 	}
-
-	if v3valueFound == false {
-		log.Log.Error(err, "could not parse crd schema", "name", crdName)
-	}
+	return v3valueFound
 }
 
 // addingDefaultFieldsToSchema will add any default missing fields like apiVersion, metadata

--- a/pkg/openapi/crdSync.go
+++ b/pkg/openapi/crdSync.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -13,11 +14,11 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/googleapis/gnostic/compiler"
 
 	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	"github.com/nirmata/kyverno/pkg/constant"
 	client "github.com/nirmata/kyverno/pkg/dclient"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -157,13 +158,27 @@ func (o *Controller) ParseCRD(crd unstructured.Unstructured) {
 
 	parsedSchema, err := openapi_v2.NewSchema(schema, compiler.NewContext("schema", nil))
 	if err != nil {
-		log.Log.Error(err, "could not parse crd schema", "name", crdName)
-		return
+		isOpenV3Error(err, crdName)
 	}
 
 	o.crdList = append(o.crdList, crdName)
 	o.kindToDefinitionName[crdName] = crdName
 	o.definitions[crdName] = parsedSchema
+}
+
+func isOpenV3Error(err error, crdName string) {
+	unsupportedValues := []string{"anyOf", "allOf", "not"}
+	v3valueFound := false
+	for _, value := range unsupportedValues {
+		if !strings.Contains(err.Error(), fmt.Sprintf("has invalid property: %s", value)) {
+			v3valueFound = true
+			break
+		}
+	}
+
+	if v3valueFound == false {
+		log.Log.Error(err, "could not parse crd schema", "name", crdName)
+	}
 }
 
 // addingDefaultFieldsToSchema will add any default missing fields like apiVersion, metadata


### PR DESCRIPTION
## Related issue

closes #954
close #1050

**What type of PR is this?**
> /kind feature

## Proposed changes
Ignoring the error for fields - allOf, anyOf, oneOf and not.


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](documentation/).

## Further comments
Kubernetes doesn't support openAPIV3 yet. Kubernetes itself doesn't validate for anyOf, allOf, not, OneOf - https://github.com/kubernetes/apiextensions-apiserver/blob/a704491594d836db7402ab8609c72ce891ffbebe/pkg/controller/openapi/v2/conversion.go#L36
