### PR TITLE
Parse string value to array from configMap

### DIFF
--- a/documentation/writing-policies-configmap-reference.md
+++ b/documentation/writing-policies-configmap-reference.md
@@ -8,7 +8,7 @@ The Configmap Reference allows the reference of configmap values inside kyverno 
 
 # Defining Rule Context
 
-To refer Configmap inside any Rule provide the context inside each rule defining the list of configmaps which will be referenced in that Rule.
+To reference values from a ConfigMap inside any Rule, define a context inside the rule with one or more ConfigMap declarations.
 
 ````yaml
   rules:
@@ -37,19 +37,19 @@ metadata:
 
 # Referring Value
 
-The configmaps that are defined inside rule context can be referred using the unique name that is used to identify configmap inside context.
+A ConfigMap that is defined inside the rule context can be referred to using its unique name within the context.
 
-We can refer it's value using a JMESPATH `{{<name>.<data>.<key>}}`. 
+ConfigMap values can be references using a JMESPATH expression `{{<name>.<data>.<key>}}`.
 
-For the above context we can refer it's value by `{{dictionary.data.env}}`, which will be substitued with `production` during policy application.
+For the example above, we can refer to a ConfigMap value using {{dictionary.data.env}}. The variable will be substituted with production during policy execution.
 
-# Deal with Array of Values
+# Handling Array Values
 
-The substitute variable can be an array of values. It allows the JSON format when defining it in the configMap.
+The ConfigMap value can be an array of string values in JSON format. Kyverno will parse the JSON string to a list of strings, so set operations like In and NotIn can then be applied.
 
-For example, a list of allowed roles can be stored in configMap, and the kyverno policy can refer to this list to deny the disallowed request.
+For example, a list of allowed roles can be stored in a ConfigMap, and the Kyverno policy can refer to this list to deny the requests where the role does not match the one of the values in the list.
 
-Here is the allowed roles in configMap:
+Here are the allowed roles in the ConfigMap
 ````yaml
 apiVersion: v1
 data:

--- a/documentation/writing-policies-configmap-reference.md
+++ b/documentation/writing-policies-configmap-reference.md
@@ -10,41 +10,84 @@ The Configmap Reference allows the reference of configmap values inside kyverno 
 
 To refer Configmap inside any Rule provide the context inside each rule defining the list of configmaps which will be referenced in that Rule.
 
-```
+````yaml
   rules:
-    - name: add-sidecar-pod
+    - name: example-configmap-lookup
       # added context to define the configmap information which will be referred 
       context:
       # unique name to identify configmap
-      - name: mycmapRef
+      - name: dictionary
         configMap: 
           # configmap name - name of the configmap which will be referred
           name: mycmap
           # configmap namepsace - namespace of the configmap which will be referred
-```
+          namespace: test
+````
 
 Referenced Configmap Definition
 
-```
+````yaml
 apiVersion: v1
 data:
-  env: production, sandbox, staging
+  env: production
 kind: ConfigMap
 metadata:
   name: mycmap
-```
+````
 
 # Referring Value
 
 The configmaps that are defined inside rule context can be referred using the unique name that is used to identify configmap inside context.
 
-We can refer it's value using a JMESPATH
+We can refer it's value using a JMESPATH `{{<name>.<data>.<key>}}`. 
 
-`{{<name>.<data>.<key>}}`
+For the above context we can refer it's value by `{{dictionary.data.env}}`, which will be substitued with `production` during policy application.
 
-So for the above context we can refer it's value using
+# Deal with Array of Values
 
-`{{mycmapRef.data.env}}`
+The substitute variable can be an array of values. It allows the JSON format when defining it in the configMap.
+
+For example, a list of allowed roles can be stored in configMap, and the kyverno policy can refer to this list to deny the disallowed request.
+
+Here is the allowed roles in configMap:
+````yaml
+apiVersion: v1
+data:
+  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
+kind: ConfigMap
+metadata:
+  name: roles-dictionary
+  namespace: test
+````
+
+
+This is a rule to deny the Deployment operation, if the value of annotation `role` is not in the allowed list:
+````yaml
+spec:
+  validationFailureAction: enforce
+  rules:
+  - name: validate-role-annotation
+    context:
+      - name: roles-dictionary
+        configMap: 
+          name: roles-dictionary
+          namespace: test
+    match:
+      resources:
+        kinds:
+        - Deployment
+    preconditions:
+    - key: "{{ request.object.metadata.annotations.role }}"
+      operator: NotEquals
+      value: ""
+    validate:
+      message: "role {{ request.object.metadata.annotations.role }} is not in the allowed list {{ \"roles-dictionary\".data.\"allowed-roles\" }}"
+      deny:
+        conditions: 
+        - key: "{{ request.object.metadata.annotations.role }}"
+          operator: NotIn
+          value:  "{{ \"roles-dictionary\".data.\"allowed-roles\" }}"
+````
 
 
 

--- a/pkg/engine/mutate/patchesUtils.go
+++ b/pkg/engine/mutate/patchesUtils.go
@@ -29,7 +29,6 @@ func generatePatches(src, dst []byte) ([][]byte, error) {
 		}
 
 		patchesBytes = append(patchesBytes, pbytes)
-		// fmt.Printf("generated patch %s\n", p)
 	}
 
 	return patchesBytes, err

--- a/pkg/engine/utils.go
+++ b/pkg/engine/utils.go
@@ -4,14 +4,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/nirmata/kyverno/pkg/utils"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
-	"time"
 
 	"github.com/minio/minio/pkg/wildcard"
 	kyverno "github.com/nirmata/kyverno/pkg/api/kyverno/v1"

--- a/pkg/engine/variables/operator/notin.go
+++ b/pkg/engine/variables/operator/notin.go
@@ -47,7 +47,7 @@ func (nin NotInHandler) Evaluate(key, value interface{}) bool {
 }
 
 func (nin NotInHandler) validateValuewithStringPattern(key string, value interface{}) bool {
-	invalidType, keyExists := ValidateStringPattern(key, value)
+	invalidType, keyExists := ValidateStringPattern(key, value, nin.log)
 	if invalidType {
 		nin.log.Info("expected type []string", "value", value, "type", fmt.Sprintf("%T", value))
 		return false

--- a/test/e2e/generate/utils.go
+++ b/test/e2e/generate/utils.go
@@ -1,14 +1,15 @@
 package generate
 
 import (
+	"os"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
 	"sigs.k8s.io/yaml"
-	"time"
 )
 
 type E2EClient struct {
@@ -103,7 +104,6 @@ func (e2e *E2EClient) ListNamespacedResources(gvr schema.GroupVersionResource, n
 func (e2e *E2EClient) CreateNamespacedResourceYaml(gvr schema.GroupVersionResource, namespace string, resourceData []byte) (*unstructured.Unstructured, error) {
 	resource := unstructured.Unstructured{}
 	err := yaml.Unmarshal(resourceData, &resource)
-	// fmt.Println(resource)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In #724, we support configMap lookup. This PR is to handle an array that is defined in the configMap. 

For example, with the following configMap,
````yaml
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
kind: ConfigMap
````

The value of `allowed-roles` will be converted to array for operator `In` `NotIn` operation.