### PR TITLE
fix: Partial Scan when Git Source Paths are involved (kyverno-cli apply command)

### DIFF
--- a/cmd/cli/kubectl-kyverno/oci/oci_push.go
+++ b/cmd/cli/kubectl-kyverno/oci/oci_push.go
@@ -36,7 +36,7 @@ kyverno oci push -p policies. -i <imgref>`,
 				return errors.New("image reference is required")
 			}
 
-			policies, errs := common.GetPolicies([]string{policyRef})
+			policies, errs := common.GetPolicies([]string{policyRef}, "")
 			if len(errs) != 0 {
 				return fmt.Errorf("unable to read policy file or directory %s: %w", policyRef, multierr.Combine(errs...))
 			}


### PR DESCRIPTION
## Explanation
Ideally, when `kyverno-cli apply` command is executed, it should be able to take different kinds of paths(filePath, directoryPath, GitPath,... ) and scan against all the policies in the given paths. But, when Git Source paths are involved only policies from few paths are included. Here are different cases:
* In the given paths, if the first path is not a Git Source Path and there is a Git Source Path in the subsequent paths, `the policies in the Git Source Path are neglected`. 
* If the first path is a Git Source Path, `only policies from the first Git Path are included`. Policies are excluded from the remaining paths, even if the path is a Git Source Path.   

## Reason:
All the paths are considered Git Source Paths if the first path is a Git Source Path and vice versa.

## Proposed Changes
Reading and categorizing the path individually will do the trick. A little refactor could accomplish this. 
Currently, the policies from the Git Source Path are extracted in the very beginning, separate from remaining kind of paths. Instead of doing that, extracting the policies of Git Source Paths along with other kind of Paths and reading them individually just like other kind of paths will solve the issue. 