### PR TITLE
point cli test to nirmata policies fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -645,7 +645,7 @@ test-cli: test-cli-policies test-cli-local test-cli-local-mutate test-cli-local-
 .PHONY: test-cli-policies
 test-cli-policies: $(CLI_BIN)
 	@echo Testing against branch $(TEST_GIT_BRANCH)...
-	@$(CLI_BIN) test https://github.com/kyverno/policies/$(TEST_GIT_BRANCH)
+	@$(CLI_BIN) test https://github.com/nirmata/policies/$(TEST_GIT_BRANCH)
 
 .PHONY: test-cli-local
 test-cli-local: $(CLI_BIN)


### PR DESCRIPTION
## Explanation

The kyverno-cli tests were referring to the upstream policies repository. Changing this to downstream, such that the corresponding branch is available.