### PR TITLE
Adds changes for configuring webhooks dynamically

### DIFF
--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -51,6 +51,10 @@ const (
 	IdleDeadline              = tickerInterval * 10
 	maxRetries                = 10
 	tickerInterval            = 10 * time.Second
+	webhookCreate             = "CREATE"
+	webhookUpdate             = "UPDATE"
+	webhookDelete             = "DELETE"
+	webhookConnect            = "CONNECT"
 )
 
 var (
@@ -640,6 +644,7 @@ func (c *controller) buildResourceMutatingWebhookConfiguration(ctx context.Conte
 			return nil, err
 		}
 		c.recordPolicyState(config.MutatingWebhookConfigurationName, policies...)
+		operationStatusMap := getOperationStatusMap()
 		for _, p := range policies {
 			if p.AdmissionProcessingEnabled() {
 				spec := p.GetSpec()
@@ -651,7 +656,10 @@ func (c *controller) buildResourceMutatingWebhookConfiguration(ctx context.Conte
 					}
 				}
 			}
+			rules := p.GetSpec().Rules
+			operationStatusMap = computeOperationsForMutatingWebhookConf(rules, operationStatusMap)
 		}
+		operationReq := getMinimumOperations(operationStatusMap)
 		webhookCfg := config.WebhookConfig{}
 		webhookCfgs := cfg.GetWebhooks()
 		if len(webhookCfgs) > 0 {
@@ -664,7 +672,7 @@ func (c *controller) buildResourceMutatingWebhookConfiguration(ctx context.Conte
 				admissionregistrationv1.MutatingWebhook{
 					Name:                    config.MutatingWebhookName + "-ignore",
 					ClientConfig:            c.clientConfig(caBundle, config.MutatingWebhookServicePath+"/ignore"),
-					Rules:                   ignore.buildRulesWithOperations(admissionregistrationv1.Create, admissionregistrationv1.Update),
+					Rules:                   ignore.buildRulesWithOperations(operationReq...),
 					FailurePolicy:           &ignore.failurePolicy,
 					SideEffects:             &noneOnDryRun,
 					AdmissionReviewVersions: []string{"v1"},
@@ -683,7 +691,7 @@ func (c *controller) buildResourceMutatingWebhookConfiguration(ctx context.Conte
 				admissionregistrationv1.MutatingWebhook{
 					Name:                    config.MutatingWebhookName + "-fail",
 					ClientConfig:            c.clientConfig(caBundle, config.MutatingWebhookServicePath+"/fail"),
-					Rules:                   fail.buildRulesWithOperations(admissionregistrationv1.Create, admissionregistrationv1.Update),
+					Rules:                   fail.buildRulesWithOperations(operationReq...),
 					FailurePolicy:           &fail.failurePolicy,
 					SideEffects:             &noneOnDryRun,
 					AdmissionReviewVersions: []string{"v1"},
@@ -753,6 +761,111 @@ func (c *controller) buildDefaultResourceValidatingWebhookConfiguration(_ contex
 		nil
 }
 
+func scanResourceFilter(resFilter kyvernov1.ResourceFilters, operationStatusMap map[string]bool) (bool, map[string]bool) {
+	opFound := false
+	for _, rf := range resFilter {
+		if rf.ResourceDescription.Operations != nil {
+			for _, o := range rf.ResourceDescription.Operations {
+				opFound = true
+				operationStatusMap[string(o)] = true
+			}
+		}
+	}
+	return opFound, operationStatusMap
+}
+
+func computeOperationsForValidatingWebhookConf(rules []kyvernov1.Rule, operationStatusMap map[string]bool) map[string]bool {
+	for _, r := range rules {
+		opFound := false
+		if len(r.MatchResources.Any) != 0 {
+			opFound, operationStatusMap = scanResourceFilter(r.MatchResources.Any, operationStatusMap)
+		}
+		if len(r.MatchResources.All) != 0 {
+			opFound, operationStatusMap = scanResourceFilter(r.MatchResources.All, operationStatusMap)
+		}
+		if len(r.ExcludeResources.Any) != 0 {
+			opFound, operationStatusMap = scanResourceFilter(r.ExcludeResources.Any, operationStatusMap)
+		}
+		if len(r.ExcludeResources.All) != 0 {
+			opFound, operationStatusMap = scanResourceFilter(r.ExcludeResources.All, operationStatusMap)
+		}
+		if r.MatchResources.ResourceDescription.Operations != nil {
+			for _, o := range r.MatchResources.ResourceDescription.Operations {
+				opFound = true
+				operationStatusMap[string(o)] = true
+			}
+		}
+		if r.ExcludeResources.ResourceDescription.Operations != nil {
+			for _, o := range r.ExcludeResources.ResourceDescription.Operations {
+				opFound = true
+				operationStatusMap[string(o)] = true
+			}
+		}
+		if !opFound {
+			operationStatusMap[webhookCreate] = true
+			operationStatusMap[webhookUpdate] = true
+			operationStatusMap[webhookConnect] = true
+			operationStatusMap[webhookDelete] = true
+		}
+	}
+	return operationStatusMap
+}
+
+func computeOperationsForMutatingWebhookConf(rules []kyvernov1.Rule, operationStatusMap map[string]bool) map[string]bool {
+	for _, r := range rules {
+		opFound := false
+		if len(r.MatchResources.Any) != 0 {
+			opFound, operationStatusMap = scanResourceFilter(r.MatchResources.Any, operationStatusMap)
+		}
+		if len(r.MatchResources.All) != 0 {
+			opFound, operationStatusMap = scanResourceFilter(r.MatchResources.All, operationStatusMap)
+		}
+		if len(r.ExcludeResources.Any) != 0 {
+			opFound, operationStatusMap = scanResourceFilter(r.ExcludeResources.Any, operationStatusMap)
+		}
+		if len(r.ExcludeResources.All) != 0 {
+			opFound, operationStatusMap = scanResourceFilter(r.ExcludeResources.All, operationStatusMap)
+		}
+		if r.MatchResources.ResourceDescription.Operations != nil {
+			for _, o := range r.MatchResources.ResourceDescription.Operations {
+				opFound = true
+				operationStatusMap[string(o)] = true
+			}
+		}
+		if r.ExcludeResources.ResourceDescription.Operations != nil {
+			for _, o := range r.ExcludeResources.ResourceDescription.Operations {
+				opFound = true
+				operationStatusMap[string(o)] = true
+			}
+		}
+		if !opFound {
+			operationStatusMap[webhookCreate] = true
+			operationStatusMap[webhookUpdate] = true
+		}
+	}
+	return operationStatusMap
+}
+
+func getMinimumOperations(operationStatusMap map[string]bool) []admissionregistrationv1.OperationType {
+	operationReq := make([]admissionregistrationv1.OperationType, 0, 4)
+	for k, v := range operationStatusMap {
+		if v {
+			var oper admissionregistrationv1.OperationType = admissionregistrationv1.OperationType(k)
+			operationReq = append(operationReq, oper)
+		}
+	}
+	return operationReq
+}
+
+func getOperationStatusMap() map[string]bool {
+	operationStatusMap := make(map[string]bool)
+	operationStatusMap[webhookCreate] = false
+	operationStatusMap[webhookUpdate] = false
+	operationStatusMap[webhookDelete] = false
+	operationStatusMap[webhookConnect] = false
+	return operationStatusMap
+}
+
 func (c *controller) buildResourceValidatingWebhookConfiguration(ctx context.Context, cfg config.Configuration, caBundle []byte) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 	result := admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: objectMeta(config.ValidatingWebhookConfigurationName, cfg.GetWebhookAnnotations(), c.buildOwner()...),
@@ -766,6 +879,7 @@ func (c *controller) buildResourceValidatingWebhookConfiguration(ctx context.Con
 			return nil, err
 		}
 		c.recordPolicyState(config.ValidatingWebhookConfigurationName, policies...)
+		operationStatusMap := getOperationStatusMap()
 		for _, p := range policies {
 			if p.AdmissionProcessingEnabled() {
 				spec := p.GetSpec()
@@ -777,7 +891,10 @@ func (c *controller) buildResourceValidatingWebhookConfiguration(ctx context.Con
 					}
 				}
 			}
+			rules := p.GetSpec().Rules
+			operationStatusMap = computeOperationsForValidatingWebhookConf(rules, operationStatusMap)
 		}
+		operationsNeeded := getMinimumOperations(operationStatusMap)
 		webhookCfg := config.WebhookConfig{}
 		webhookCfgs := cfg.GetWebhooks()
 		if len(webhookCfgs) > 0 {
@@ -794,7 +911,7 @@ func (c *controller) buildResourceValidatingWebhookConfiguration(ctx context.Con
 				admissionregistrationv1.ValidatingWebhook{
 					Name:                    config.ValidatingWebhookName + "-ignore",
 					ClientConfig:            c.clientConfig(caBundle, config.ValidatingWebhookServicePath+"/ignore"),
-					Rules:                   ignore.buildRulesWithOperations(admissionregistrationv1.Create, admissionregistrationv1.Update, admissionregistrationv1.Delete, admissionregistrationv1.Connect),
+					Rules:                   ignore.buildRulesWithOperations(operationsNeeded...),
 					FailurePolicy:           &ignore.failurePolicy,
 					SideEffects:             sideEffects,
 					AdmissionReviewVersions: []string{"v1"},
@@ -812,7 +929,7 @@ func (c *controller) buildResourceValidatingWebhookConfiguration(ctx context.Con
 				admissionregistrationv1.ValidatingWebhook{
 					Name:                    config.ValidatingWebhookName + "-fail",
 					ClientConfig:            c.clientConfig(caBundle, config.ValidatingWebhookServicePath+"/fail"),
-					Rules:                   fail.buildRulesWithOperations(admissionregistrationv1.Create, admissionregistrationv1.Update, admissionregistrationv1.Delete, admissionregistrationv1.Connect),
+					Rules:                   fail.buildRulesWithOperations(operationsNeeded...),
 					FailurePolicy:           &fail.failurePolicy,
 					SideEffects:             sideEffects,
 					AdmissionReviewVersions: []string{"v1"},

--- a/pkg/controllers/webhook/controller_test.go
+++ b/pkg/controllers/webhook/controller_test.go
@@ -1,0 +1,187 @@
+package webhook
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	v1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+)
+
+func TestGetMinimumOperations(t *testing.T) {
+	testCases := []struct {
+		name           string
+		inputMap       map[string]bool
+		expectedResult []admissionregistrationv1.OperationType
+	}{
+		{
+			name: "Test Case 1",
+			inputMap: map[string]bool{
+				"CREATE": true,
+				"UPDATE": false,
+				"DELETE": true,
+			},
+			expectedResult: []admissionregistrationv1.OperationType{"CREATE", "DELETE"},
+		},
+		{
+			name: "Test Case 2",
+			inputMap: map[string]bool{
+				"CREATE":  false,
+				"UPDATE":  false,
+				"DELETE":  false,
+				"CONNECT": true,
+			},
+			expectedResult: []admissionregistrationv1.OperationType{"CONNECT"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := getMinimumOperations(testCase.inputMap)
+			sort.Slice(result, func(i, j int) bool {
+				return result[i] < result[j]
+			})
+			sort.Slice(testCase.expectedResult, func(i, j int) bool {
+				return testCase.expectedResult[i] < testCase.expectedResult[j]
+			})
+
+			if !reflect.DeepEqual(result, testCase.expectedResult) {
+				t.Errorf("Expected %v, but got %v", testCase.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestComputeOperationsForMutatingWebhookConf(t *testing.T) {
+	testCases := []struct {
+		name           string
+		rules          []kyvernov1.Rule
+		expectedResult map[string]bool
+	}{
+		{
+			name: "Test Case 1",
+			rules: []kyvernov1.Rule{
+				{
+					MatchResources: kyvernov1.MatchResources{
+						ResourceDescription: kyvernov1.ResourceDescription{
+							Operations: []v1.AdmissionOperation{"CREATE"},
+						},
+					},
+				},
+			},
+			expectedResult: map[string]bool{
+				"CREATE": true,
+			},
+		},
+		{
+			name: "Test Case 2",
+			rules: []kyvernov1.Rule{
+				{
+					MatchResources:   kyvernov1.MatchResources{},
+					ExcludeResources: kyvernov1.MatchResources{},
+				},
+				{
+					MatchResources:   kyvernov1.MatchResources{},
+					ExcludeResources: kyvernov1.MatchResources{},
+				},
+			},
+			expectedResult: map[string]bool{
+				webhookCreate: true,
+				webhookUpdate: true,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := computeOperationsForMutatingWebhookConf(testCase.rules, make(map[string]bool))
+			if !reflect.DeepEqual(result, testCase.expectedResult) {
+				t.Errorf("Expected %v, but got %v", testCase.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestComputeOperationsForValidatingWebhookConf(t *testing.T) {
+	testCases := []struct {
+		name           string
+		rules          []kyvernov1.Rule
+		expectedResult map[string]bool
+	}{
+		{
+			name: "Test Case 1",
+			rules: []kyvernov1.Rule{
+				{
+					MatchResources: kyvernov1.MatchResources{
+						ResourceDescription: kyvernov1.ResourceDescription{
+							Operations: []v1.AdmissionOperation{"CREATE"},
+						},
+					},
+				},
+				{
+					ExcludeResources: kyvernov1.MatchResources{
+						ResourceDescription: kyvernov1.ResourceDescription{
+							Operations: []v1.AdmissionOperation{"DELETE"},
+						},
+					},
+				},
+			},
+			expectedResult: map[string]bool{
+				"CREATE": true,
+				"DELETE": true,
+			},
+		},
+		{
+			name: "Test Case 2",
+			rules: []kyvernov1.Rule{
+				{
+					MatchResources:   kyvernov1.MatchResources{},
+					ExcludeResources: kyvernov1.MatchResources{},
+				},
+				{
+					MatchResources:   kyvernov1.MatchResources{},
+					ExcludeResources: kyvernov1.MatchResources{},
+				},
+			},
+			expectedResult: map[string]bool{
+				webhookCreate:  true,
+				webhookUpdate:  true,
+				webhookConnect: true,
+				webhookDelete:  true,
+			},
+		},
+		{
+			name: "Test Case 3",
+			rules: []kyvernov1.Rule{
+				{
+					MatchResources: kyvernov1.MatchResources{
+						ResourceDescription: kyvernov1.ResourceDescription{
+							Operations: []v1.AdmissionOperation{"CREATE", "UPDATE"},
+						},
+					},
+					ExcludeResources: kyvernov1.MatchResources{
+						ResourceDescription: kyvernov1.ResourceDescription{
+							Operations: []v1.AdmissionOperation{"DELETE"},
+						},
+					},
+				},
+			},
+			expectedResult: map[string]bool{
+				webhookCreate: true,
+				webhookUpdate: true,
+				"DELETE":      true,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := computeOperationsForValidatingWebhookConf(testCase.rules, make(map[string]bool))
+			if !reflect.DeepEqual(result, testCase.expectedResult) {
+				t.Errorf("Expected %v, but got %v", testCase.expectedResult, result)
+			}
+		})
+	}
+}

--- a/test/conformance/kuttl/webhooks/dynamic-op-mutate/01-policy.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op-mutate/01-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- policy.yaml
+assert:
+- policy-assert.yaml

--- a/test/conformance/kuttl/webhooks/dynamic-op-mutate/02-resource.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op-mutate/02-resource.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- file: resource.yaml
+  shouldFail: false

--- a/test/conformance/kuttl/webhooks/dynamic-op-mutate/03-webhooks.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op-mutate/03-webhooks.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+assert:
+- webhooks.yaml

--- a/test/conformance/kuttl/webhooks/dynamic-op-mutate/README.md
+++ b/test/conformance/kuttl/webhooks/dynamic-op-mutate/README.md
@@ -1,0 +1,3 @@
+## Description
+
+This test verifies that operations configured dynmically are correct in mutatingwebhookconfiguration

--- a/test/conformance/kuttl/webhooks/dynamic-op-mutate/policy-assert.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op-mutate/policy-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-apparmor-annotations
+status:
+  conditions:
+    - reason: Succeeded
+      status: "True"
+      type: Ready

--- a/test/conformance/kuttl/webhooks/dynamic-op-mutate/policy.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op-mutate/policy.yaml
@@ -1,0 +1,26 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-apparmor-annotations
+  annotations:
+    policies.kyverno.io/title: Add AppArmor Annotations
+    policies.kyverno.io/category: PSP Migration
+    policies.kyverno.io/subject: Pod,Annotation
+    kyverno.io/kyverno-version: 1.10.0    
+spec:
+  rules:
+  - name: apparmor-runtime-default
+    match:
+      any:
+      - resources:
+          kinds:
+          - '*/scale'
+          operations:
+          - CREATE
+    mutate:
+      foreach:
+      - list: request.object.spec.containers[]
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              "container.apparmor.security.beta.kubernetes.io/{{element.name}}": runtime/default

--- a/test/conformance/kuttl/webhooks/dynamic-op-mutate/resource.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op-mutate/resource.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/test/conformance/kuttl/webhooks/dynamic-op-mutate/webhooks.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op-mutate/webhooks.yaml
@@ -1,0 +1,18 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-mutating-webhook-cfg
+webhooks:
+- rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    resources:
+    - '*/scale'
+    scope: '*'
+

--- a/test/conformance/kuttl/webhooks/dynamic-op/01-policy.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op/01-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- policy.yaml
+assert:
+- policy-assert.yaml

--- a/test/conformance/kuttl/webhooks/dynamic-op/02-webhooks.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op/02-webhooks.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+assert:
+- webhooks.yaml

--- a/test/conformance/kuttl/webhooks/dynamic-op/README.md
+++ b/test/conformance/kuttl/webhooks/dynamic-op/README.md
@@ -1,0 +1,3 @@
+## Description
+
+This test verifies that operations configured dynmically are correct

--- a/test/conformance/kuttl/webhooks/dynamic-op/policy-assert.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op/policy-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-labels
+status:
+  conditions:
+    - reason: Succeeded
+      status: "True"
+      type: Ready

--- a/test/conformance/kuttl/webhooks/dynamic-op/policy.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op/policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-labels
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  validationFailureAction: Audit
+  background: false
+  rules:
+    - name: require-team
+      match:
+        any:
+          - resources:
+              kinds:
+                - '*/scale'
+              operations:
+              - CREATE
+      validate:
+        message: 'The label `team` is required.'
+        pattern:
+          metadata:
+            labels:
+              team: '?*'

--- a/test/conformance/kuttl/webhooks/dynamic-op/webhooks.yaml
+++ b/test/conformance/kuttl/webhooks/dynamic-op/webhooks.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    webhook.kyverno.io/managed-by: kyverno
+  name: kyverno-resource-validating-webhook-cfg
+webhooks:
+- rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    resources:
+    - '*/scale'
+    scope: '*'


### PR DESCRIPTION
## Explanation
In this PR we want to try to configure the minimum set of operations required if policies have match.operations and/or exclude.operations configured.
By default in Validating webhook contains CREATE, UPDATE, DELETE, CONNECT and mutating webhook contains CREATE and UPDATE. Only if the policies mention in match or exclude block a set of operations do we add a subset of default operations in the webhook configurations.
We do not look in the preconditions (only match and exclude blocks).
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
NDEV-17348
https://github.com/kyverno/kyverno/pull/8437
