### PR TITLE
Disable autogeneration of webhooks

### DIFF
--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -120,7 +120,6 @@ func main() {
 				webhookControllerName,
 				genericwebhookcontroller.NewController(
 					webhookControllerName,
-					// if condition based on flags ?
 					setup.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations(),
 					kubeInformer.Admissionregistration().V1().ValidatingWebhookConfigurations(),
 					kubeKyvernoInformer.Core().V1().Secrets(),

--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -50,12 +50,14 @@ func (probes) IsLive() bool {
 
 func main() {
 	var (
-		dumpPayload bool
-		serverIP    string
-		servicePort int
+		dumpPayload             bool
+		disallowValidateWebhook bool
+		serverIP                string
+		servicePort             int
 	)
 	flagset := flag.NewFlagSet("cleanup-controller", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
+	flagset.BoolVar(&disallowValidateWebhook, "disallowValidateWebhook", true, "Set this flag to 'false' to disable validate webhook.")
 	flagset.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")
 	flagset.IntVar(&servicePort, "servicePort", 443, "Port used by the Kyverno Service resource and for webhook configurations.")
 	// config
@@ -118,6 +120,7 @@ func main() {
 				webhookControllerName,
 				genericwebhookcontroller.NewController(
 					webhookControllerName,
+					// if condition based on flags ?
 					setup.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations(),
 					kubeInformer.Admissionregistration().V1().ValidatingWebhookConfigurations(),
 					kubeKyvernoInformer.Core().V1().Secrets(),

--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -57,7 +57,7 @@ func main() {
 	)
 	flagset := flag.NewFlagSet("cleanup-controller", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
-	flagset.BoolVar(&disableAutoWebhookGeneration, "disableAutoWebhookGeneration", true, "Set this flag to disable automatic webhook generation.")
+	flagset.BoolVar(&disableAutoWebhookGeneration, "disableAutoWebhookGeneration", false, "Set this flag to disable automatic webhook generation.")
 	flagset.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")
 	flagset.IntVar(&servicePort, "servicePort", 443, "Port used by the Kyverno Service resource and for webhook configurations.")
 	// config
@@ -145,6 +145,7 @@ func main() {
 					genericwebhookcontroller.Fail,
 					genericwebhookcontroller.None,
 					setup.Configuration,
+					disableAutoWebhookGeneration,
 				),
 				webhookWorkers,
 			)

--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -50,14 +50,14 @@ func (probes) IsLive() bool {
 
 func main() {
 	var (
-		dumpPayload             bool
-		disallowValidateWebhook bool
-		serverIP                string
-		servicePort             int
+		dumpPayload                  bool
+		disableAutoWebhookGeneration bool
+		serverIP                     string
+		servicePort                  int
 	)
 	flagset := flag.NewFlagSet("cleanup-controller", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
-	flagset.BoolVar(&disallowValidateWebhook, "disallowValidateWebhook", true, "Set this flag to 'false' to disable validate webhook.")
+	flagset.BoolVar(&disableAutoWebhookGeneration, "disableAutoWebhookGeneration", true, "Set this flag to disable automatic webhook generation.")
 	flagset.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")
 	flagset.IntVar(&servicePort, "servicePort", 443, "Port used by the Kyverno Service resource and for webhook configurations.")
 	// config

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -180,6 +180,8 @@ func main() {
 		maxQueuedEvents              int
 		omitEvents                   string
 		autoUpdateWebhooks           bool
+		disallowValidateWebhook      bool
+		disallowMutateWebhook        bool
 		webhookRegistrationTimeout   time.Duration
 		admissionReports             bool
 		dumpPayload                  bool
@@ -193,6 +195,8 @@ func main() {
 	flagset.StringVar(&omitEvents, "omit-events", "", "Set this flag to a comma sperated list of PolicyViolation, PolicyApplied, PolicyError, PolicySkipped to disable events, e.g. --omit-events=PolicyApplied,PolicyViolation")
 	flagset.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")
 	flagset.BoolVar(&autoUpdateWebhooks, "autoUpdateWebhooks", true, "Set this flag to 'false' to disable auto-configuration of the webhook.")
+	flagset.BoolVar(&disallowValidateWebhook, "disallowValidateWebhook", true, "Set this flag to 'false' to disable validate webhook.")
+	flagset.BoolVar(&disallowMutateWebhook, "disallowMutateWebhook", true, "Set this flag to 'false' to disable mutate of the webhook.")
 	flagset.DurationVar(&webhookRegistrationTimeout, "webhookRegistrationTimeout", 120*time.Second, "Timeout for webhook registration, e.g., 30s, 1m, 5m.")
 	flagset.Func(toggle.ProtectManagedResourcesFlagName, toggle.ProtectManagedResourcesDescription, toggle.ProtectManagedResources.Parse)
 	flagset.Func(toggle.ForceFailurePolicyIgnoreFlagName, toggle.ForceFailurePolicyIgnoreDescription, toggle.ForceFailurePolicyIgnore.Parse)
@@ -450,6 +454,7 @@ func main() {
 			}
 			return secret.Data[corev1.TLSCertKey], secret.Data[corev1.TLSPrivateKeyKey], nil
 		},
+		// if conditions based on flags ?
 		setup.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations(),
 		setup.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations(),
 		setup.KubeClient.CoordinationV1().Leases(config.KyvernoNamespace()),

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -101,6 +101,7 @@ func createrLeaderControllers(
 	admissionReports bool,
 	serverIP string,
 	webhookTimeout int,
+	disableAutoWebhookGeneration bool,
 	autoUpdateWebhooks bool,
 	kubeInformer kubeinformers.SharedInformerFactory,
 	kubeKyvernoInformer kubeinformers.SharedInformerFactory,
@@ -133,6 +134,7 @@ func createrLeaderControllers(
 		serverIP,
 		int32(webhookTimeout),
 		servicePort,
+		disableAutoWebhookGeneration,
 		autoUpdateWebhooks,
 		admissionReports,
 		runtime,
@@ -161,6 +163,7 @@ func createrLeaderControllers(
 		genericwebhookcontroller.Fail,
 		genericwebhookcontroller.None,
 		configuration,
+		disableAutoWebhookGeneration,
 	)
 	return []internal.Controller{
 			internal.NewController(certmanager.ControllerName, certManager, certmanager.Workers),
@@ -190,7 +193,7 @@ func main() {
 	flagset := flag.NewFlagSet("kyverno", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
 	flagset.IntVar(&webhookTimeout, "webhookTimeout", webhookcontroller.DefaultWebhookTimeout, "Timeout for webhook configurations.")
-	flagset.BoolVar(&disableAutoWebhookGeneration, "disableAutoWebhookGeneration", true, "Set this flag to disable automatic webhook generation.")
+	flagset.BoolVar(&disableAutoWebhookGeneration, "disableAutoWebhookGeneration", false, "Set this flag to disable automatic webhook generation.")
 	flagset.IntVar(&maxQueuedEvents, "maxQueuedEvents", 1000, "Maximum events to be queued.")
 	flagset.StringVar(&omitEvents, "omit-events", "", "Set this flag to a comma sperated list of PolicyViolation, PolicyApplied, PolicyError, PolicySkipped to disable events, e.g. --omit-events=PolicyApplied,PolicyViolation")
 	flagset.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")
@@ -349,6 +352,7 @@ func main() {
 				admissionReports,
 				serverIP,
 				webhookTimeout,
+				disableAutoWebhookGeneration,
 				autoUpdateWebhooks,
 				kubeInformer,
 				kubeKyvernoInformer,

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -456,7 +456,6 @@ func main() {
 			}
 			return secret.Data[corev1.TLSCertKey], secret.Data[corev1.TLSPrivateKeyKey], nil
 		},
-		// if conditions based on flags ?
 		setup.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations(),
 		setup.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations(),
 		setup.KubeClient.CoordinationV1().Leases(config.KyvernoNamespace()),

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -176,12 +176,11 @@ func main() {
 		// TODO: this has been added to backward support command line arguments
 		// will be removed in future and the configuration will be set only via configmaps
 		serverIP                     string
+		disableAutoWebhookGeneration bool
 		webhookTimeout               int
 		maxQueuedEvents              int
 		omitEvents                   string
 		autoUpdateWebhooks           bool
-		disallowValidateWebhook      bool
-		disallowMutateWebhook        bool
 		webhookRegistrationTimeout   time.Duration
 		admissionReports             bool
 		dumpPayload                  bool
@@ -191,12 +190,11 @@ func main() {
 	flagset := flag.NewFlagSet("kyverno", flag.ExitOnError)
 	flagset.BoolVar(&dumpPayload, "dumpPayload", false, "Set this flag to activate/deactivate debug mode.")
 	flagset.IntVar(&webhookTimeout, "webhookTimeout", webhookcontroller.DefaultWebhookTimeout, "Timeout for webhook configurations.")
+	flagset.BoolVar(&disableAutoWebhookGeneration, "disableAutoWebhookGeneration", true, "Set this flag to disable automatic webhook generation.")
 	flagset.IntVar(&maxQueuedEvents, "maxQueuedEvents", 1000, "Maximum events to be queued.")
 	flagset.StringVar(&omitEvents, "omit-events", "", "Set this flag to a comma sperated list of PolicyViolation, PolicyApplied, PolicyError, PolicySkipped to disable events, e.g. --omit-events=PolicyApplied,PolicyViolation")
 	flagset.StringVar(&serverIP, "serverIP", "", "IP address where Kyverno controller runs. Only required if out-of-cluster.")
 	flagset.BoolVar(&autoUpdateWebhooks, "autoUpdateWebhooks", true, "Set this flag to 'false' to disable auto-configuration of the webhook.")
-	flagset.BoolVar(&disallowValidateWebhook, "disallowValidateWebhook", true, "Set this flag to 'false' to disable validate webhook.")
-	flagset.BoolVar(&disallowMutateWebhook, "disallowMutateWebhook", true, "Set this flag to 'false' to disable mutate of the webhook.")
 	flagset.DurationVar(&webhookRegistrationTimeout, "webhookRegistrationTimeout", 120*time.Second, "Timeout for webhook registration, e.g., 30s, 1m, 5m.")
 	flagset.Func(toggle.ProtectManagedResourcesFlagName, toggle.ProtectManagedResourcesDescription, toggle.ProtectManagedResources.Parse)
 	flagset.Func(toggle.ForceFailurePolicyIgnoreFlagName, toggle.ForceFailurePolicyIgnoreDescription, toggle.ForceFailurePolicyIgnore.Parse)


### PR DESCRIPTION
NDEV-17919

Proposed solution:

I have added a new flag `disableAutoWebhookGeneration` which is set to false by default (within admission controller as well as cleanup controller). If set to true, kyverno doesnt generate webhooks and expects the webhooks to be created by the user.

The webhooks required are:
```
kyverno-exception-validating-webhook-cfg  
kyverno-policy-validating-webhook-cfg      
kyverno-resource-validating-webhook-cfg    
kyverno-cleanup-validating-webhook-cfg    
kyverno-policy-mutating-webhook-cfg      
kyverno-resource-mutating-webhook-cfg    
kyverno-verify-mutating-webhook-cfg
```

A sample for this that I used was:
```vwc.yaml
apiVersion: v1
items:
- apiVersion: admissionregistration.k8s.io/v1
  kind: ValidatingWebhookConfiguration
  metadata:
    generation: 1
    labels:
      webhook.kyverno.io/managed-by: kyverno
    name: kyverno-exception-validating-webhook-cfg
    resourceVersion: "728"
    uid: 4a70d000-f87b-4a0a-bcfb-20d53fd8ba8a
  webhooks:
  - admissionReviewVersions:
    - v1
    clientConfig:
      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSXpNVEl4TWpBME5ETXpPRm9YRFRJME1USXhNVEExTkRNek9Gb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTGFhMnQ5NXF5M0ZtbURPU0dpL2JwdXZjM0JyM1RCaDVYWjJWK3kzVUIyb0VDakxiMUMwOVk0cWZBSlMKOHVHN1kyNzVzL1k5K0I5L2YxT3U4Mjh6ZzdXWU9HcENSVlYwUjhSZVk3Ym1Gc0RaUmFRdWhTSGV1bHlLRXVkZwpuRWNtbXd1UklaYUN6Q0ZwVVF4eFRPbk5sNmJQSXczbmwzMkt3NDJRZFljbGZuTUZXd3lLTGRhMFBSdlpnei9qCkpMSzdyak5pbjRYYmswSjN2YUhkZ0drNU1kMEtBalRaaXpQSVcreXZRMWRIME92NnRYYnFxVGkrb3JmNVFNbEoKZkxHODc2dEk0TmdpOUhkcWZJMktSS0hLQTJhY2pQVG10OWVpRGZod2xib0pmTVlraE1Qb1d0dkt1aWRCM0F6NgpvZXBWV0o3RFlOR3JtNmJ5akU1eVpHeThHSmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRlB5bGZNZWg4TEwvNXU2ME42dmdQak9TMU1ETE1BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJ4TE5Ia1ZGZ2krS2lBMTBMektyRHNFMklFdmIyNldHQUpoaHhZaVdMeQpScmlWS3I4UEoyU3JPWExoTXZ6VXhPbHpJT2UwZGZtcWhzQ0xpOFhsWXFDUFZoa0RzMTdPdHo3Z0RCVjFHWkZjClJGUVBOdWo4U09wR2RrSy9sS0F1Szd4NlcyRm9ySG9kbGVvWWdaSG8xM2ZobkpGNFM5SUhPeTdCd3cvT2pUSFcKc3ZKNEY5TXdxYWVJcTF3d2RBamNLeHU3bzBRWWZqOVY4MkJmYTV4Q1RTSzY3cmdpbWpkT2lwM2p3UnluN3FmbAo3ckpqdjVQMTlqQVBFVE1sYUUvWFlyaXlJa1M0V2RQZ2I5aVV3cFVrcTFUUm5YdHU3NURpMUFEUGdOTE5WRmwrCmxxcnExZTlIU0xlekVKWVpoOStVNlA3T3I3b3ltUjlnaXJ0cnJaM0g1VzJlCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
      url: https://192.168.1.7:9443/exceptionvalidate
    failurePolicy: Fail
    matchPolicy: Equivalent
    name: kyverno-svc.kyverno.svc
    namespaceSelector: {}
    objectSelector: {}
    rules:
    - apiGroups:
      - kyverno.io
      apiVersions:
      - v2alpha1
      operations:
      - CREATE
      - UPDATE
      resources:
      - policyexceptions
      scope: '*'
    sideEffects: None
    timeoutSeconds: 10
- apiVersion: admissionregistration.k8s.io/v1
  kind: ValidatingWebhookConfiguration
  metadata:
    generation: 1
    labels:
      webhook.kyverno.io/managed-by: kyverno
    name: kyverno-policy-validating-webhook-cfg
    resourceVersion: "729"
    uid: f2af90b3-4aa6-4dd7-8270-96c951bca506
  webhooks:
  - admissionReviewVersions:
    - v1
    clientConfig:
      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSXpNVEl4TWpBME5ETXpPRm9YRFRJME1USXhNVEExTkRNek9Gb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTGFhMnQ5NXF5M0ZtbURPU0dpL2JwdXZjM0JyM1RCaDVYWjJWK3kzVUIyb0VDakxiMUMwOVk0cWZBSlMKOHVHN1kyNzVzL1k5K0I5L2YxT3U4Mjh6ZzdXWU9HcENSVlYwUjhSZVk3Ym1Gc0RaUmFRdWhTSGV1bHlLRXVkZwpuRWNtbXd1UklaYUN6Q0ZwVVF4eFRPbk5sNmJQSXczbmwzMkt3NDJRZFljbGZuTUZXd3lLTGRhMFBSdlpnei9qCkpMSzdyak5pbjRYYmswSjN2YUhkZ0drNU1kMEtBalRaaXpQSVcreXZRMWRIME92NnRYYnFxVGkrb3JmNVFNbEoKZkxHODc2dEk0TmdpOUhkcWZJMktSS0hLQTJhY2pQVG10OWVpRGZod2xib0pmTVlraE1Qb1d0dkt1aWRCM0F6NgpvZXBWV0o3RFlOR3JtNmJ5akU1eVpHeThHSmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRlB5bGZNZWg4TEwvNXU2ME42dmdQak9TMU1ETE1BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJ4TE5Ia1ZGZ2krS2lBMTBMektyRHNFMklFdmIyNldHQUpoaHhZaVdMeQpScmlWS3I4UEoyU3JPWExoTXZ6VXhPbHpJT2UwZGZtcWhzQ0xpOFhsWXFDUFZoa0RzMTdPdHo3Z0RCVjFHWkZjClJGUVBOdWo4U09wR2RrSy9sS0F1Szd4NlcyRm9ySG9kbGVvWWdaSG8xM2ZobkpGNFM5SUhPeTdCd3cvT2pUSFcKc3ZKNEY5TXdxYWVJcTF3d2RBamNLeHU3bzBRWWZqOVY4MkJmYTV4Q1RTSzY3cmdpbWpkT2lwM2p3UnluN3FmbAo3ckpqdjVQMTlqQVBFVE1sYUUvWFlyaXlJa1M0V2RQZ2I5aVV3cFVrcTFUUm5YdHU3NURpMUFEUGdOTE5WRmwrCmxxcnExZTlIU0xlekVKWVpoOStVNlA3T3I3b3ltUjlnaXJ0cnJaM0g1VzJlCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
      url: https://192.168.1.7:9443/policyvalidate
    failurePolicy: Fail
    matchPolicy: Equivalent
    name: validate-policy.kyverno.svc
    namespaceSelector: {}
    objectSelector: {}
    rules:
    - apiGroups:
      - kyverno.io
      apiVersions:
      - v1
      - v2beta1
      operations:
      - CREATE
      - UPDATE
      resources:
      - clusterpolicies
      - policies
      scope: '*'
    sideEffects: None
    timeoutSeconds: 10
- apiVersion: admissionregistration.k8s.io/v1
  kind: ValidatingWebhookConfiguration
  metadata:
    generation: 1
    labels:
      webhook.kyverno.io/managed-by: kyverno
    name: kyverno-resource-validating-webhook-cfg
    resourceVersion: "732"
    uid: 064d5c43-7ec8-49cd-b284-e8e9fa19cd70
kind: List
metadata:
  resourceVersion: ""
```
```mwc.yaml
apiVersion: v1
items:
- apiVersion: admissionregistration.k8s.io/v1
  kind: MutatingWebhookConfiguration
  metadata:
    generation: 1
    labels:
      webhook.kyverno.io/managed-by: kyverno
    name: kyverno-policy-mutating-webhook-cfg
    resourceVersion: "730"
    uid: 83a6c3d7-ad13-419a-9363-a1ad70e377cb
  webhooks:
  - admissionReviewVersions:
    - v1
    clientConfig:
      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSXpNVEl4TWpBME5ETXpPRm9YRFRJME1USXhNVEExTkRNek9Gb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTGFhMnQ5NXF5M0ZtbURPU0dpL2JwdXZjM0JyM1RCaDVYWjJWK3kzVUIyb0VDakxiMUMwOVk0cWZBSlMKOHVHN1kyNzVzL1k5K0I5L2YxT3U4Mjh6ZzdXWU9HcENSVlYwUjhSZVk3Ym1Gc0RaUmFRdWhTSGV1bHlLRXVkZwpuRWNtbXd1UklaYUN6Q0ZwVVF4eFRPbk5sNmJQSXczbmwzMkt3NDJRZFljbGZuTUZXd3lLTGRhMFBSdlpnei9qCkpMSzdyak5pbjRYYmswSjN2YUhkZ0drNU1kMEtBalRaaXpQSVcreXZRMWRIME92NnRYYnFxVGkrb3JmNVFNbEoKZkxHODc2dEk0TmdpOUhkcWZJMktSS0hLQTJhY2pQVG10OWVpRGZod2xib0pmTVlraE1Qb1d0dkt1aWRCM0F6NgpvZXBWV0o3RFlOR3JtNmJ5akU1eVpHeThHSmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRlB5bGZNZWg4TEwvNXU2ME42dmdQak9TMU1ETE1BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJ4TE5Ia1ZGZ2krS2lBMTBMektyRHNFMklFdmIyNldHQUpoaHhZaVdMeQpScmlWS3I4UEoyU3JPWExoTXZ6VXhPbHpJT2UwZGZtcWhzQ0xpOFhsWXFDUFZoa0RzMTdPdHo3Z0RCVjFHWkZjClJGUVBOdWo4U09wR2RrSy9sS0F1Szd4NlcyRm9ySG9kbGVvWWdaSG8xM2ZobkpGNFM5SUhPeTdCd3cvT2pUSFcKc3ZKNEY5TXdxYWVJcTF3d2RBamNLeHU3bzBRWWZqOVY4MkJmYTV4Q1RTSzY3cmdpbWpkT2lwM2p3UnluN3FmbAo3ckpqdjVQMTlqQVBFVE1sYUUvWFlyaXlJa1M0V2RQZ2I5aVV3cFVrcTFUUm5YdHU3NURpMUFEUGdOTE5WRmwrCmxxcnExZTlIU0xlekVKWVpoOStVNlA3T3I3b3ltUjlnaXJ0cnJaM0g1VzJlCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
      url: https://192.168.1.7:9443/policymutate
    failurePolicy: Fail
    matchPolicy: Equivalent
    name: mutate-policy.kyverno.svc
    namespaceSelector: {}
    objectSelector: {}
    reinvocationPolicy: IfNeeded
    rules:
    - apiGroups:
      - kyverno.io
      apiVersions:
      - v1
      - v2beta1
      operations:
      - CREATE
      - UPDATE
      resources:
      - clusterpolicies
      - policies
      scope: '*'
    sideEffects: NoneOnDryRun
    timeoutSeconds: 10
- apiVersion: admissionregistration.k8s.io/v1
  kind: MutatingWebhookConfiguration
  metadata:
    generation: 1
    labels:
      webhook.kyverno.io/managed-by: kyverno
    name: kyverno-resource-mutating-webhook-cfg
    resourceVersion: "731"
    uid: 15e02bad-10c3-4b1e-b1db-2511edb96539
- apiVersion: admissionregistration.k8s.io/v1
  kind: MutatingWebhookConfiguration
  metadata:
    generation: 1
    labels:
      webhook.kyverno.io/managed-by: kyverno
    name: kyverno-verify-mutating-webhook-cfg
    resourceVersion: "733"
    uid: f49623ad-332c-4848-b214-0bac19c83586
  webhooks:
  - admissionReviewVersions:
    - v1
    clientConfig:
      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSXpNVEl4TWpBME5ETXpPRm9YRFRJME1USXhNVEExTkRNek9Gb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBTGFhMnQ5NXF5M0ZtbURPU0dpL2JwdXZjM0JyM1RCaDVYWjJWK3kzVUIyb0VDakxiMUMwOVk0cWZBSlMKOHVHN1kyNzVzL1k5K0I5L2YxT3U4Mjh6ZzdXWU9HcENSVlYwUjhSZVk3Ym1Gc0RaUmFRdWhTSGV1bHlLRXVkZwpuRWNtbXd1UklaYUN6Q0ZwVVF4eFRPbk5sNmJQSXczbmwzMkt3NDJRZFljbGZuTUZXd3lLTGRhMFBSdlpnei9qCkpMSzdyak5pbjRYYmswSjN2YUhkZ0drNU1kMEtBalRaaXpQSVcreXZRMWRIME92NnRYYnFxVGkrb3JmNVFNbEoKZkxHODc2dEk0TmdpOUhkcWZJMktSS0hLQTJhY2pQVG10OWVpRGZod2xib0pmTVlraE1Qb1d0dkt1aWRCM0F6NgpvZXBWV0o3RFlOR3JtNmJ5akU1eVpHeThHSmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRlB5bGZNZWg4TEwvNXU2ME42dmdQak9TMU1ETE1BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJ4TE5Ia1ZGZ2krS2lBMTBMektyRHNFMklFdmIyNldHQUpoaHhZaVdMeQpScmlWS3I4UEoyU3JPWExoTXZ6VXhPbHpJT2UwZGZtcWhzQ0xpOFhsWXFDUFZoa0RzMTdPdHo3Z0RCVjFHWkZjClJGUVBOdWo4U09wR2RrSy9sS0F1Szd4NlcyRm9ySG9kbGVvWWdaSG8xM2ZobkpGNFM5SUhPeTdCd3cvT2pUSFcKc3ZKNEY5TXdxYWVJcTF3d2RBamNLeHU3bzBRWWZqOVY4MkJmYTV4Q1RTSzY3cmdpbWpkT2lwM2p3UnluN3FmbAo3ckpqdjVQMTlqQVBFVE1sYUUvWFlyaXlJa1M0V2RQZ2I5aVV3cFVrcTFUUm5YdHU3NURpMUFEUGdOTE5WRmwrCmxxcnExZTlIU0xlekVKWVpoOStVNlA3T3I3b3ltUjlnaXJ0cnJaM0g1VzJlCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
      url: https://192.168.1.7:9443/verifymutate
    failurePolicy: Ignore
    matchPolicy: Equivalent
    name: monitor-webhooks.kyverno.svc
    namespaceSelector: {}
    objectSelector:
      matchLabels:
        app.kubernetes.io/name: kyverno
    reinvocationPolicy: IfNeeded
    rules:
    - apiGroups:
      - coordination.k8s.io
      apiVersions:
      - v1
      operations:
      - UPDATE
      resources:
      - leases
      scope: '*'
    sideEffects: NoneOnDryRun
    timeoutSeconds: 10
kind: List
metadata:
  resourceVersion: ""
```
```cleanupwebhook.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  generation: 1
  labels:
    webhook.kyverno.io/managed-by: kyverno
  name: kyverno-cleanup-validating-webhook-cfg
  resourceVersion: "894"
  uid: a45e368d-6b7f-4b66-8b07-a48705cdcde6
webhooks:
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM3VENDQWRXZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFZTVJZd0ZBWURWUVFEREEwcUxtdDUKZG1WeWJtOHVjM1pqTUI0WERUSXpNVEl4TWpBME5EZ3lNMW9YRFRJME1USXhNVEExTkRneU0xb3dHREVXTUJRRwpBMVVFQXd3TktpNXJlWFpsY201dkxuTjJZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBS2h5Y1A5bE5tM3NTelI2UG8vVDN3aWp6TE5PN254ejU1RGNQUmdEK0lNOS9tTE9yak11dVArVU5nU08Kd253NTBYSFZMQ2dHMzZ6MmcyOHM5Y01Ea0RxRSsxWDVwWlgrSW1hMXY5TFZ1Tm1HeVRyNUZaM0x6OXFxcnZiTApWZEhKUmRxa0xHVlUzRjdHdE9Ma0M2UGg3R0R6SkwzWG9WOWs5RUVlLzE5ZFNpV2FIbzY3T1paK28yaWE2aWlBCk1UaEcyZmxncnYrV01TZUFabTJyby92RGhJamNhR3ZrTm81Q25hdEEvSG9ScjlPS2EyL3AzNGN4bEkzVWVjb3QKL2FWWWNtL3YzdG5FU2FYMDFueng0QXFZdjNxWjA3aU95UGRzV2U5aFFIdXVZcUlXZGExRnZTYlRvdW9LV3dZaQpPdGliN0hXdnFtd2dQU3N4YTczbXpFcTlVTmNDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHCkExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkpBYnlUKzBqcmxidGVEMkIzZTJWbGplcjlYVU1BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUEra29zY1hkQjJmVGhVT3hBOS9MakE4MFlmN1c0MkI4VVZ3L3kzYll4cwovaW5wR2J2TEgyQXQ5K2g2SXkxZVVhbkM0RTJFVlJrWUJKTVZaT1dmOUVSdmpLd2JEbFZkVWJyL3FiUnl3eU91ClQvZkUvanBRVnh4djVITXVhdUVuY0ZDMVlYUUhHUkxReFZST2lIeGhnVUs3QjN3NXREUHBNbzJsMlJWZE1kMFMKdElOY3VITTdQaHJGOTNlMkRZditTdksyb2krd1RjVC9BWnIrZlo2NmIvazNzVS8yQm9neG9GNHJUckFrSXZBMwpvbmJSR3hFelFTZm1xSlVLa3FNa2ZDcUJjdE9JNTZNVzZJY3JSbXJsWVZQMUpiSVYrQllFYzB1OURYaVo0QU1SCkcydVZWV01RMElHSWVxV2h2STBOQkE5ZHpPQ1B4SmM5SjlPUmdFd084UHdTCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    url: https://<SERVER-IP>:9443/validate
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: kyverno-svc.kyverno.svc
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - kyverno.io
    apiVersions:
    - v2alpha1
    operations:
    - CREATE
    - UPDATE
    resources:
    - cleanuppolicies/*
    - clustercleanuppolicies/*
    scope: '*'
  sideEffects: None
  timeoutSeconds: 10
```
Note: need to be careful with the caBundle, if `admissionController.createSelfSignedCert` is set to false, kyverno creates the cert, and the webhook should contain the same info. Else, you can manage the cert and add that to the webhooks.