### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/nightly-scan.yaml
+++ b/.github/workflows/nightly-scan.yaml
@@ -49,14 +49,14 @@ jobs:
 
       - name: Scan image using grype
         id: grype-scan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a  # v3
         with:
           image: ${{ env.IMAGE_NAME }}
           severity-cutoff: low
           fail-build: true
 
       - name: Scan image using trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # master
         id: trivy-scan
         with:
           image-ref: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `anchore/scan-action@v3 -> @3343887d...`
- `aquasecurity/trivy-action@master -> @57a97c7e...`


### Why

Following the [TeamPCP/Checkmarx supply chain attack](https://thehackernews.com/2026/03/teampcp-hacks-checkmarx-github-actions.html), Nirmata is hardening all public repos against GitHub Actions tag hijacking. This repo was flagged as **CRITICAL** (unpinned actions + write permissions).

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
